### PR TITLE
refactor: rename `forkTsCheckerOptions` to `tsCheckerOptions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ pluginTypeCheck({
 });
 ```
 
-### forkTsCheckerOptions
+### tsCheckerOptions
 
 Modify the options of `ts-checker-rspack-plugin`, please refer to [ts-checker-rspack-plugin - README](https://github.com/rspack-contrib/ts-checker-rspack-plugin#readme) to learn about available options.
 
@@ -136,11 +136,11 @@ const defaultOptions = {
 
 #### Object Type
 
-When the value of `forkTsCheckerOptions` is an object, it will be deeply merged with the default configuration.
+When the value of `tsCheckerOptions` is an object, it will be deeply merged with the default configuration.
 
 ```ts
 pluginTypeCheck({
-  forkTsCheckerOptions: {
+  tsCheckerOptions: {
     issue: {
       exclude: [({ file = "" }) => /[\\/]some-folder[\\/]/.test(file)],
     },
@@ -150,11 +150,11 @@ pluginTypeCheck({
 
 #### Function Type
 
-When the value of `forkTsCheckerOptions` is a function, the default configuration will be passed as the first argument. You can directly modify the configuration object or return an object as the final configuration.
+When the value of `tsCheckerOptions` is a function, the default configuration will be passed as the first argument. You can directly modify the configuration object or return an object as the final configuration.
 
 ```ts
 pluginTypeCheck({
-  forkTsCheckerOptions(options) {
+  tsCheckerOptions(options) {
     options.async = false;
     return options;
   },
@@ -169,7 +169,7 @@ For example, the type mismatch error can be excluded using `code: 'TS2345'`:
 
 ```ts
 pluginTypeCheck({
-  forkTsCheckerOptions: {
+  tsCheckerOptions: {
     issue: {
       // Ignore "Argument of type 'string' is not assignable to parameter of type 'number'.ts(2345)"
       exclude: [{ code: "TS2345" }],
@@ -182,7 +182,7 @@ Or exclude files under `/some-folder/` using `file`:
 
 ```ts
 pluginTypeCheck({
-  forkTsCheckerOptions: {
+  tsCheckerOptions: {
     issue: {
       exclude: [({ file = "" }) => /[\\/]some-folder[\\/]/.test(file)],
     },

--- a/test/basic/index.test.ts
+++ b/test/basic/index.test.ts
@@ -44,7 +44,7 @@ test('should throw error when exist type errors in dev mode', async ({
     rsbuildConfig: {
       plugins: [
         pluginTypeCheck({
-          forkTsCheckerOptions: {
+          tsCheckerOptions: {
             async: false,
           },
         }),
@@ -81,7 +81,7 @@ test('should not throw error when the file is excluded', async () => {
     rsbuildConfig: {
       plugins: [
         pluginTypeCheck({
-          forkTsCheckerOptions: {
+          tsCheckerOptions: {
             issue: {
               exclude: [{ file: '**/index.ts' }],
             },
@@ -100,7 +100,7 @@ test('should not throw error when the file is excluded by code', async () => {
     rsbuildConfig: {
       plugins: [
         pluginTypeCheck({
-          forkTsCheckerOptions: {
+          tsCheckerOptions: {
             issue: {
               exclude: [{ code: 'TS2345' }],
             },


### PR DESCRIPTION
Rename the `forkTsCheckerOptions` option to `tsCheckerOptions` throughout the codebase, ensuring consistency and clarity.

The changes also include deprecation of the old option name and updates to relevant documentation and tests.

The `forkTsCheckerOptions` option still works as before.