### PR TITLE
feat: should display error in overlay when exist type errors in dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ pluginTypeCheck({
 });
 ```
 
-#### Disable type errors in the error overlay
+#### Disable type errors from the error overlay
 
 By default, type errors will be reported to Dev Server and displayed in the Rsbuild error overlay in development mode.
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,20 @@ pluginTypeCheck({
 });
 ```
 
+#### Disable type errors in the error overlay
+
+By default, type errors will be reported to Dev Server and displayed in the Rsbuild error overlay in development mode.
+
+If you don't want type errors to be displayed in the error overlay, you can disable it by setting `devServer: false`:
+
+```ts
+pluginTypeCheck({
+  tsCheckerOptions: {
+    async: true,
+    devServer: false,
+  },
+});
+```
 ## Notes
 
 - If you have enabled `ts-loader` in your project and manually configured `compileOnly: false`, please disable the Type Check plugin to avoid duplicate type checking.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "deepmerge": "^4.3.1",
-    "ts-checker-rspack-plugin": "^1.0.1",
+    "ts-checker-rspack-plugin": "^1.1.0",
     "json5": "^2.2.3",
     "reduce-configs": "^1.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       ts-checker-rspack-plugin:
-        specifier: ^1.0.1
-        version: 1.0.1(@rspack/core@1.1.4(@swc/helpers@0.5.15))(typescript@5.7.2)
+        specifier: ^1.1.0
+        version: 1.1.0(@rspack/core@1.1.4(@swc/helpers@0.5.15))(typescript@5.7.2)
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.4
@@ -461,15 +461,15 @@ packages:
     peerDependencies:
       tslib: '2'
 
-  ts-checker-rspack-plugin@1.0.1:
-    resolution: {integrity: sha512-u+RgBXBr6RHCJ+nJtA3A6MG3oDt20faU8DryX+H3HPhhU+cCnrGY304vmwOsQLJmoMWDk7/xkkbz2j9pC0aX1Q==}
+  ts-checker-rspack-plugin@1.1.0:
+    resolution: {integrity: sha512-nhUzSuSjfgVAJjc+vJa9q8uE7MxAbustG9InRp4ylMfIbkqyJjh7gSuEcL//l76ZSwoKcCod+5lv2mNO0Ugh8g==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@rspack/core': ^1.0.0
       typescript: '>=3.8.0'
-
-  tslib@2.6.2:
-    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -539,21 +539,21 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
-  '@jsonjoy.com/base64@1.1.2(tslib@2.6.2)':
+  '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.1
 
-  '@jsonjoy.com/json-pack@1.1.0(tslib@2.6.2)':
+  '@jsonjoy.com/json-pack@1.1.0(tslib@2.8.1)':
     dependencies:
-      '@jsonjoy.com/base64': 1.1.2(tslib@2.6.2)
-      '@jsonjoy.com/util': 1.5.0(tslib@2.6.2)
+      '@jsonjoy.com/base64': 1.1.2(tslib@2.8.1)
+      '@jsonjoy.com/util': 1.5.0(tslib@2.8.1)
       hyperdyperid: 1.2.0
-      thingies: 1.21.0(tslib@2.6.2)
-      tslib: 2.6.2
+      thingies: 1.21.0(tslib@2.8.1)
+      tslib: 2.8.1
 
-  '@jsonjoy.com/util@1.5.0(tslib@2.6.2)':
+  '@jsonjoy.com/util@1.5.0(tslib@2.8.1)':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   '@module-federation/runtime-tools@0.5.1':
     dependencies:
@@ -768,10 +768,10 @@ snapshots:
 
   memfs@4.14.0:
     dependencies:
-      '@jsonjoy.com/json-pack': 1.1.0(tslib@2.6.2)
-      '@jsonjoy.com/util': 1.5.0(tslib@2.6.2)
-      tree-dump: 1.0.2(tslib@2.6.2)
-      tslib: 2.6.2
+      '@jsonjoy.com/json-pack': 1.1.0(tslib@2.8.1)
+      '@jsonjoy.com/util': 1.5.0(tslib@2.8.1)
+      tree-dump: 1.0.2(tslib@2.8.1)
+      tslib: 2.8.1
 
   minimatch@9.0.5:
     dependencies:
@@ -820,9 +820,9 @@ snapshots:
     dependencies:
       has-flag: 3.0.0
 
-  thingies@1.21.0(tslib@2.6.2):
+  thingies@1.21.0(tslib@2.8.1):
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   tinyglobby@0.2.10:
     dependencies:
@@ -833,22 +833,21 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  tree-dump@1.0.2(tslib@2.6.2):
+  tree-dump@1.0.2(tslib@2.8.1):
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.1
 
-  ts-checker-rspack-plugin@1.0.1(@rspack/core@1.1.4(@swc/helpers@0.5.15))(typescript@5.7.2):
+  ts-checker-rspack-plugin@1.1.0(@rspack/core@1.1.4(@swc/helpers@0.5.15))(typescript@5.7.2):
     dependencies:
       '@babel/code-frame': 7.24.7
-      '@rspack/core': 1.1.4(@swc/helpers@0.5.15)
       '@rspack/lite-tapable': 1.0.1
       chokidar: 3.6.0
       memfs: 4.14.0
       minimatch: 9.0.5
       picocolors: 1.1.1
       typescript: 5.7.2
-
-  tslib@2.6.2: {}
+    optionalDependencies:
+      '@rspack/core': 1.1.4(@swc/helpers@0.5.15)
 
   tslib@2.8.1: {}
 

--- a/test/basic/index.test.ts
+++ b/test/basic/index.test.ts
@@ -75,6 +75,39 @@ test('should throw error when exist type errors in dev mode', async ({
   await server.close();
 });
 
+test('should display error in overlay when exist type errors in dev mode', async ({
+  page,
+}) => {
+  const { restore } = proxyConsole();
+
+  const rsbuild = await createRsbuild({
+    cwd: __dirname,
+    rsbuildConfig: {
+      plugins: [pluginTypeCheck()],
+      server: {
+        port: getRandomPort(),
+      },
+    },
+  });
+
+  const { server, urls } = await rsbuild.startDevServer();
+
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+
+  await page.goto(urls[0]);
+
+  const errorOverlay = page.locator('rsbuild-error-overlay');
+
+  expect(
+    (await errorOverlay.locator('.content').allInnerTexts()).find((txt) =>
+      txt.includes('TS2345: Argument of type'),
+    ),
+  ).toBeDefined();
+
+  restore();
+  await server.close();
+});
+
 test('should not throw error when the file is excluded', async () => {
   const rsbuild = await createRsbuild({
     cwd: __dirname,


### PR DESCRIPTION
bump `ts-checker-rspack-plugin` to support display error in overlay when exist type errors in dev mode
Related PR: https://github.com/rspack-contrib/ts-checker-rspack-plugin/pull/15

resolve: https://github.com/web-infra-dev/rsbuild/issues/4232