### PR TITLE
chore: enable OIDC publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Pnpm
-        run: npm i -g corepack@latest --force && corepack enable
+      # Update npm to the latest version to enable OIDC
+      # Use corepack to install pnpm
+      - name: Setup Package Managers
+        run: |
+          npm install -g npm@latest
+          npm --version
+          npm install -g corepack@latest --force
+          corepack enable
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.14
+          node-version: 22
           cache: "pnpm"
 
       - name: Install Dependencies
@@ -36,7 +42,7 @@ jobs:
       - name: Publish
         uses: JS-DevTools/npm-publish@v3
         with:
-          token: ${{ secrets.RSBUILD_PLUGIN_NPM_TOKEN }}
+          token: empty
 
       - name: Create GitHub Release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
Enable OIDC publishing to make it easier and more secure to publish npm packages from CI.

- https://github.com/orgs/community/discussions/127011
- https://github.com/npm/cli/pull/8336