### PR TITLE
feat: support typescript-go checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ const defaultOptions = {
 
 #### TypeScript Go support
 
-To enable experimental TypeScript Go support, install `@typescript/native-preview` and set `typescript.tsgo` to `true`:
+TypeScript Go support is powered by `ts-checker-rspack-plugin`'s experimental, CLI-based integration for [typescript-go](https://github.com/microsoft/typescript-go). It runs the `tsgo` binary for type checking and can reduce type-checking time by about 5-10x.
+
+To enable it, install `@typescript/native-preview` and set `typescript.tsgo` to `true`:
 
 ```ts
 pluginTypeCheck({
@@ -153,7 +155,9 @@ pluginTypeCheck({
 });
 ```
 
-When `tsgo` is enabled, the default `typescript.typescriptPath` resolves to `@typescript/native-preview/package.json`. In `tsgo` mode, `typescript.typescriptPath` must be an absolute path to `@typescript/native-preview/package.json`. For more usage details and limitations, see [ts-checker-rspack-plugin - TypeScript Go support](https://github.com/rstackjs/ts-checker-rspack-plugin#typescript-go-support).
+When `tsgo` is enabled, the default `typescript.typescriptPath` resolves to `@typescript/native-preview/package.json`. If you set `typescript.typescriptPath` manually in `tsgo` mode, it must be an absolute path to `@typescript/native-preview/package.json`.
+
+For supported options and limitations, see [ts-checker-rspack-plugin - TypeScript Go support](https://github.com/rstackjs/ts-checker-rspack-plugin#typescript-go-support).
 
 #### Object Type
 

--- a/README.md
+++ b/README.md
@@ -117,8 +117,11 @@ const defaultOptions = {
     memoryLimit: 8192,
     // use tsconfig of user project
     configFile: tsconfigPath,
+    tsgo: false,
     // use typescript of user project
-    typescriptPath: require.resolve('typescript'),
+    typescriptPath: tsgo
+      ? require.resolve('@typescript/native-preview/package.json')
+      : require.resolve('typescript'),
   },
   issue: {
     // ignore types errors from node_modules
@@ -135,6 +138,22 @@ const defaultOptions = {
   },
 };
 ```
+
+#### TypeScript Go support
+
+To enable experimental TypeScript Go support, install `@typescript/native-preview` and set `typescript.tsgo` to `true`:
+
+```ts
+pluginTypeCheck({
+  tsCheckerOptions: {
+    typescript: {
+      tsgo: true,
+    },
+  },
+});
+```
+
+When `tsgo` is enabled, the default `typescript.typescriptPath` resolves to `@typescript/native-preview/package.json`. In `tsgo` mode, `typescript.typescriptPath` must be an absolute path to `@typescript/native-preview/package.json`. For more usage details and limitations, see [ts-checker-rspack-plugin - TypeScript Go support](https://github.com/rstackjs/ts-checker-rspack-plugin#typescript-go-support).
 
 #### Object Type
 

--- a/package.json
+++ b/package.json
@@ -17,21 +17,21 @@
   ],
   "scripts": {
     "build": "rslib",
+    "bump": "npx bumpp",
     "dev": "rslib -w",
     "lint": "rslint && prettier -c .",
     "lint:write": "rslint --fix && prettier -w .",
     "prepare": "simple-git-hooks",
-    "test": "playwright test",
-    "bump": "npx bumpp"
+    "test": "playwright test"
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm run lint:write"
   },
   "dependencies": {
     "deepmerge": "^4.3.1",
-    "ts-checker-rspack-plugin": "^1.3.1",
     "json5": "^2.2.3",
-    "reduce-configs": "^1.1.2"
+    "reduce-configs": "^1.1.2",
+    "ts-checker-rspack-plugin": "^1.4.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
@@ -40,6 +40,7 @@
     "@rslint/core": "^0.5.3",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^24.12.4",
+    "@typescript/native-preview": "7.0.0-dev.20260607.1",
     "fs-extra": "^11.3.5",
     "playwright": "^1.60.0",
     "prettier": "^3.8.3",
@@ -47,10 +48,14 @@
     "typescript": "^6.0.3"
   },
   "peerDependencies": {
-    "@rsbuild/core": "^1.0.0 || ^2.0.0"
+    "@rsbuild/core": "^1.0.0 || ^2.0.0-0",
+    "@typescript/native-preview": "^7.0.0-0"
   },
   "peerDependenciesMeta": {
     "@rsbuild/core": {
+      "optional": true
+    },
+    "@typescript/native-preview": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2
       ts-checker-rspack-plugin:
-        specifier: ^1.3.1
-        version: 1.3.1(@rspack/core@2.0.5(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@6.0.3)
+        specifier: ^1.4.0
+        version: 1.4.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@typescript/native-preview@7.0.0-dev.20260607.1)(tslib@2.8.1)(typescript@6.0.3)
     devDependencies:
       '@playwright/test':
         specifier: ^1.60.0
@@ -29,7 +29,7 @@ importers:
         version: 2.0.9
       '@rslib/core':
         specifier: ^0.22.0
-        version: 0.22.0(typescript@6.0.3)
+        version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260607.1)(typescript@6.0.3)
       '@rslint/core':
         specifier: ^0.5.3
         version: 0.5.3
@@ -39,6 +39,9 @@ importers:
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260607.1
+        version: 7.0.0-dev.20260607.1
       fs-extra:
         specifier: ^11.3.5
         version: 11.3.5
@@ -140,8 +143,8 @@ packages:
     peerDependencies:
       tslib: '2'
 
-  '@jsonjoy.com/buffers@1.0.0':
-    resolution: {integrity: sha512-NDigYR3PHqCnQLXYyoLbnEdzMMvzeiCWo1KOut7Q0CoIqg9tUAPKJ1iq/2nFhc5kZtexzutNY0LFjdwWL3Dw3Q==}
+  '@jsonjoy.com/buffers@1.2.1':
+    resolution: {integrity: sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
@@ -164,56 +167,56 @@ packages:
     peerDependencies:
       tslib: '2'
 
-  '@jsonjoy.com/fs-core@4.57.3':
-    resolution: {integrity: sha512-IvO50vkGydDZwS1e9rz/JXEtCCt9XvqxoGI6FlrVIvVm4/HpygMKW4ETtREWtMTsN5CLJ9FR6GuCduoQPZLBiw==}
+  '@jsonjoy.com/fs-core@4.57.6':
+    resolution: {integrity: sha512-uI++Wx6VkBJqVmkb4ZeExwAVpZiA2Do5NrEtXoDk0Pdvce3ytFXJoviT1sLOj16+qDIMnD5nWPfOhVpnDmRJKg==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
 
-  '@jsonjoy.com/fs-fsa@4.57.3':
-    resolution: {integrity: sha512-JlIDGUWPl7Y6zl+/ISnZuh8z2aMr/xoR66D18zlaVAuL192CvlNJEzOlzp27x4P52HRtDnCSOk6f59vTsmp5vw==}
+  '@jsonjoy.com/fs-fsa@4.57.6':
+    resolution: {integrity: sha512-pKkw/yC5CzSZKhIIUIsH1przOa+K5jGmZIg1sWaSF24JojyrUFbjcQv7QrcGAudriei6HQ6R0BFj+V8NbQinJw==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
 
-  '@jsonjoy.com/fs-node-builtins@4.57.3':
-    resolution: {integrity: sha512-JAI3PqNuY8BR7ovy4h0bADLrqJLIcUauONNZfyTxUnj3Wf3tpTYe39eJ6z7FzYyA+tdMt33VpiQQUikGr3QOBw==}
+  '@jsonjoy.com/fs-node-builtins@4.57.6':
+    resolution: {integrity: sha512-V4DgEFT3Cg5S9fCMOZSCVdTxdJWWLBO0WnAazV7hnCM96u5zXHyW/ubDAfcSVwqjkMJ50W1Y44IXtxRoIwaCVg==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
 
-  '@jsonjoy.com/fs-node-to-fsa@4.57.3':
-    resolution: {integrity: sha512-uZGxyC0zDmcmW5bfHd4YivAZ54BLlbF9G0K5rBaksI/tZdJSGM7/AC+1TY7yvFu0Wc6gUHR7mFwf6SbQ3J1BTQ==}
+  '@jsonjoy.com/fs-node-to-fsa@4.57.6':
+    resolution: {integrity: sha512-+JptNw3iifihxH2rEXrninDzX4FFVW8JD/wPR8GbJPAeL9CQUSblrlumOPB5gZuS7tYRX+PJPLtT7XzKoRhv/Q==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
 
-  '@jsonjoy.com/fs-node-utils@4.57.3':
-    resolution: {integrity: sha512-quCil8AvfcOxob4pn0drGdcQWpkPVgkt9q1+EjeyXXT40/L3l5lvYrr6hR8LmHu0eg+DNNaUwqjLT6Hr7V4sdQ==}
+  '@jsonjoy.com/fs-node-utils@4.57.6':
+    resolution: {integrity: sha512-foyUrfS7WmYEUzqYXSNxmJBcSj04TABrkpFabwO9SCDCpVCfJ+qG+2sk5FjfiflG2n0SDFZDCJ6vYlJAEpxJFg==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
 
-  '@jsonjoy.com/fs-node@4.57.3':
-    resolution: {integrity: sha512-089gZoKvbeOsT2jeBaVKSz91oFXQWFG7a62sMY6gVMHnoWbyGzTb6OVUP/V7G3wLQLJ555BEsHt8SD1nj1dgaQ==}
+  '@jsonjoy.com/fs-node@4.57.6':
+    resolution: {integrity: sha512-Kbn1jdkvDN4F2+BhoB6mMu7NCbhP0bgA5NcI1aJj/Q5UcU+I1JLLW+dEQean33iV4tXv35AzBVKPICnDltBpxw==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
 
-  '@jsonjoy.com/fs-print@4.57.3':
-    resolution: {integrity: sha512-ITwaLZpGIqD9jHndwMvDFZDIvbVzGRsJZDQ5HKln0vyMculu1c1nb7zbEBgY8BVSBZ9S2xO138OWIBGeRsrF3Q==}
+  '@jsonjoy.com/fs-print@4.57.6':
+    resolution: {integrity: sha512-96eAn4Dudtt67LTeuU47yUD+pg9/G/oKpI10zei9ljk3X3WK4lYKc+n3cpaPCAbKPzoyfxl0mXm8f8Y7BOSFXw==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
 
-  '@jsonjoy.com/fs-snapshot@4.57.3':
-    resolution: {integrity: sha512-wdNaG2DxCtvj9lKldAnEV3ycYPEpk+p2cP2lHD1qdxkoQGlWUtQverqvG9KZSkm6BHFha4PP6XRZbpARNfHRxA==}
+  '@jsonjoy.com/fs-snapshot@4.57.6':
+    resolution: {integrity: sha512-V57CMzbOgTzUWGOWQ8GzHQdpJP6JnrYVNCtTBNxVYEnlVRvo4uEJqHhtAT8vhDFrIuJOXLrTL1Fki4h5oI7xxg==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
 
-  '@jsonjoy.com/json-pack@1.14.0':
-    resolution: {integrity: sha512-LpWbYgVnKzphN5S6uss4M25jJ/9+m6q6UJoeN6zTkK4xAGhKsiBRPVeF7OYMWonn5repMQbE5vieRXcMUrKDKw==}
+  '@jsonjoy.com/json-pack@1.21.0':
+    resolution: {integrity: sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
@@ -389,8 +392,8 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/lite-tapable@1.1.0':
-    resolution: {integrity: sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==}
+  '@rspack/lite-tapable@1.1.2':
+    resolution: {integrity: sha512-1OnyWChLGE46YzWyjlmYJssOu/Y0STAnnr2ueKPqDCYTf63GJMs0mxNnCul4dNiVqHYPKv3/fxrTY3IpqoVwZQ==}
 
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
@@ -404,11 +407,55 @@ packages:
   '@types/jsonfile@6.1.4':
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
 
-  '@types/node@24.12.3':
-    resolution: {integrity: sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==}
-
   '@types/node@24.12.4':
     resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260607.1':
+    resolution: {integrity: sha512-7t6tPrvxiHTCL8Ye8H/XZDceUB/UTXerghIEBiVjoEvPK6AYxxqOB0vEhKGRhlCkUd3kQAcKQuda/SK63hBkTQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260607.1':
+    resolution: {integrity: sha512-pCzBIEDQTDaXdGdv6tQkPdnvnyLdIhSApeTjP86rvm3bfNpMbSi0DkDSQoJvEeZWYDw0ewe7TTDhbgtTSmqegQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260607.1':
+    resolution: {integrity: sha512-OAJi5GpueqRVGrtDn/N8uNRriD1OX1jvJf3GyYNMKdWw4ZAArYKAmLU0ZY4rEDj4oIV2RAHf1IGVQesCBcWqIw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260607.1':
+    resolution: {integrity: sha512-8cFWEOlCcVh8pPiqkXkjgNqPJgOk3VLtYKijMh9KAPaDFu3EBfV9pp68uteTajljPmZdX5zYkfcMzQly2RjMzg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260607.1':
+    resolution: {integrity: sha512-TGdfapfCFj4hl9M1/5oG6wjjhfoFviiMLru3a7ib63ozQwMDraJNqPrJuQ0tvVAoSMJb1wtVbvg7yYMml/KPLg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260607.1':
+    resolution: {integrity: sha512-tOEn/EC0nRnz7JHfDWwXmmBkU4dt8wdU/jYyJTOlkEhxfJtAJTjVmo4AUHwzLyV9KGIzvfymTKrQPTnD0p9ACA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260607.1':
+    resolution: {integrity: sha512-SBWFFs+MglgDrx8lh37uFHVQcljN09Z/D8Z+YwykMVKtYEIGM/i5WzS8Xpiegm9Vcqu3HTkuAfjQfy6X5MsqnA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260607.1':
+    resolution: {integrity: sha512-+DBR9iyRZiUNhJI2CqFluJLxKl3xkBGFFCADiy63pCpLVCCNuffunRhcxQ2vhnLnM3dBDoqOHE4ekKg0GfaS/Q==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
 
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -452,17 +499,12 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
 
-  glob-to-regex.js@1.0.1:
-    resolution: {integrity: sha512-CG/iEvgQqfzoVsMUbxSJcwbG2JwyZ3naEqPkeltwl0BSS8Bp83k3xlGms+0QdWFUAwV+uvo80wNswKF6FWEkKg==}
+  glob-to-regex.js@1.2.0:
+    resolution: {integrity: sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
@@ -498,8 +540,8 @@ packages:
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
-  memfs@4.57.3:
-    resolution: {integrity: sha512-dlvqataP1zUOlfj6pv9wgCSC5pRIooNntXgdLfR7FWlcKi1p8fMfJADtHp/+8Dhu5JFvMHNh7L0QVcuaaBKqqA==}
+  memfs@4.57.6:
+    resolution: {integrity: sha512-WQK+DGjKCnPdpSyJUXphz+COF2uEhhsxQ3VIWBSbzpbbXuch3h4FePMqXrXGdLjsTgo4JFzBFsP6AWd9pVazGw==}
     peerDependencies:
       tslib: '2'
 
@@ -510,8 +552,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
   picomatch@4.0.4:
@@ -560,8 +602,8 @@ packages:
     resolution: {integrity: sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==}
     hasBin: true
 
-  thingies@2.5.0:
-    resolution: {integrity: sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==}
+  thingies@2.6.0:
+    resolution: {integrity: sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==}
     engines: {node: '>=10.18'}
     peerDependencies:
       tslib: ^2
@@ -580,13 +622,16 @@ packages:
     peerDependencies:
       tslib: '2'
 
-  ts-checker-rspack-plugin@1.3.1:
-    resolution: {integrity: sha512-4VBjKblnJwypq+2aWZ9V65HENAmU/2s04d717YhLjC65MKitTTnqKeHE6GGB5C4S+2BnqZ9MtJt5AvS7nldaLQ==}
+  ts-checker-rspack-plugin@1.4.0:
+    resolution: {integrity: sha512-xPBPe6n9XZW9vMw4PFJLZFY372rejKK8UFC12i33J+yJK+fmsQQ4k9eoOlbLE0zC6vftyKDhvfMF3RyMFFTOZw==}
     peerDependencies:
-      '@rspack/core': ^1.0.0 || ^2.0.0-0
+      '@rspack/core': ^1.0.0 || ^2.0.0
+      '@typescript/native-preview': ^7.0.0-0
       typescript: '>=3.8.0'
     peerDependenciesMeta:
       '@rspack/core':
+        optional: true
+      '@typescript/native-preview':
         optional: true
 
   tslib@2.8.1:
@@ -669,7 +714,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@jsonjoy.com/buffers@1.0.0(tslib@2.8.1)':
+  '@jsonjoy.com/buffers@1.2.1(tslib@2.8.1)':
     dependencies:
       tslib: 2.8.1
 
@@ -685,71 +730,72 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@jsonjoy.com/fs-core@4.57.3(tslib@2.8.1)':
+  '@jsonjoy.com/fs-core@4.57.6(tslib@2.8.1)':
     dependencies:
-      '@jsonjoy.com/fs-node-builtins': 4.57.3(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.57.3(tslib@2.8.1)
-      thingies: 2.5.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.6(tslib@2.8.1)
+      thingies: 2.6.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@jsonjoy.com/fs-fsa@4.57.3(tslib@2.8.1)':
+  '@jsonjoy.com/fs-fsa@4.57.6(tslib@2.8.1)':
     dependencies:
-      '@jsonjoy.com/fs-core': 4.57.3(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-builtins': 4.57.3(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.57.3(tslib@2.8.1)
-      thingies: 2.5.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-core': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.6(tslib@2.8.1)
+      thingies: 2.6.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@jsonjoy.com/fs-node-builtins@4.57.3(tslib@2.8.1)':
+  '@jsonjoy.com/fs-node-builtins@4.57.6(tslib@2.8.1)':
     dependencies:
       tslib: 2.8.1
 
-  '@jsonjoy.com/fs-node-to-fsa@4.57.3(tslib@2.8.1)':
+  '@jsonjoy.com/fs-node-to-fsa@4.57.6(tslib@2.8.1)':
     dependencies:
-      '@jsonjoy.com/fs-fsa': 4.57.3(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-builtins': 4.57.3(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.57.3(tslib@2.8.1)
+      '@jsonjoy.com/fs-fsa': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.6(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@jsonjoy.com/fs-node-utils@4.57.3(tslib@2.8.1)':
+  '@jsonjoy.com/fs-node-utils@4.57.6(tslib@2.8.1)':
     dependencies:
-      '@jsonjoy.com/fs-node-builtins': 4.57.3(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.6(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@jsonjoy.com/fs-node@4.57.3(tslib@2.8.1)':
+  '@jsonjoy.com/fs-node@4.57.6(tslib@2.8.1)':
     dependencies:
-      '@jsonjoy.com/fs-core': 4.57.3(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-builtins': 4.57.3(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.57.3(tslib@2.8.1)
-      '@jsonjoy.com/fs-print': 4.57.3(tslib@2.8.1)
-      '@jsonjoy.com/fs-snapshot': 4.57.3(tslib@2.8.1)
-      glob-to-regex.js: 1.0.1(tslib@2.8.1)
-      thingies: 2.5.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-core': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-print': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-snapshot': 4.57.6(tslib@2.8.1)
+      glob-to-regex.js: 1.2.0(tslib@2.8.1)
+      thingies: 2.6.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@jsonjoy.com/fs-print@4.57.3(tslib@2.8.1)':
+  '@jsonjoy.com/fs-print@4.57.6(tslib@2.8.1)':
     dependencies:
-      '@jsonjoy.com/fs-node-utils': 4.57.3(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.6(tslib@2.8.1)
       tree-dump: 1.1.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@jsonjoy.com/fs-snapshot@4.57.3(tslib@2.8.1)':
+  '@jsonjoy.com/fs-snapshot@4.57.6(tslib@2.8.1)':
     dependencies:
       '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.57.3(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.6(tslib@2.8.1)
       '@jsonjoy.com/json-pack': 17.67.0(tslib@2.8.1)
       '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@jsonjoy.com/json-pack@1.14.0(tslib@2.8.1)':
+  '@jsonjoy.com/json-pack@1.21.0(tslib@2.8.1)':
     dependencies:
       '@jsonjoy.com/base64': 1.1.2(tslib@2.8.1)
-      '@jsonjoy.com/buffers': 1.0.0(tslib@2.8.1)
+      '@jsonjoy.com/buffers': 1.2.1(tslib@2.8.1)
       '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
       '@jsonjoy.com/json-pointer': 1.0.2(tslib@2.8.1)
       '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
       hyperdyperid: 1.2.0
-      thingies: 2.5.0(tslib@2.8.1)
+      thingies: 2.6.0(tslib@2.8.1)
+      tree-dump: 1.1.0(tslib@2.8.1)
       tslib: 2.8.1
 
   '@jsonjoy.com/json-pack@17.67.0(tslib@2.8.1)':
@@ -760,7 +806,7 @@ snapshots:
       '@jsonjoy.com/json-pointer': 17.67.0(tslib@2.8.1)
       '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
       hyperdyperid: 1.2.0
-      thingies: 2.5.0(tslib@2.8.1)
+      thingies: 2.6.0(tslib@2.8.1)
       tree-dump: 1.1.0(tslib@2.8.1)
       tslib: 2.8.1
 
@@ -777,7 +823,7 @@ snapshots:
 
   '@jsonjoy.com/util@1.9.0(tslib@2.8.1)':
     dependencies:
-      '@jsonjoy.com/buffers': 1.0.0(tslib@2.8.1)
+      '@jsonjoy.com/buffers': 1.2.1(tslib@2.8.1)
       '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
       tslib: 2.8.1
 
@@ -805,10 +851,10 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rslib/core@0.22.0(typescript@6.0.3)':
+  '@rslib/core@0.22.0(@typescript/native-preview@7.0.0-dev.20260607.1)(typescript@6.0.3)':
     dependencies:
       '@rsbuild/core': 2.0.9
-      rsbuild-plugin-dts: 0.22.0(@rsbuild/core@2.0.9)(typescript@6.0.3)
+      rsbuild-plugin-dts: 0.22.0(@rsbuild/core@2.0.9)(@typescript/native-preview@7.0.0-dev.20260607.1)(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -899,7 +945,7 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.23
 
-  '@rspack/lite-tapable@1.1.0': {}
+  '@rspack/lite-tapable@1.1.2': {}
 
   '@swc/helpers@0.5.23':
     dependencies:
@@ -913,24 +959,51 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 24.12.3
+      '@types/node': 24.12.4
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 24.12.3
-
-  '@types/node@24.12.3':
-    dependencies:
-      undici-types: 7.16.0
+      '@types/node': 24.12.4
 
   '@types/node@24.12.4':
     dependencies:
       undici-types: 7.16.0
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260607.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260607.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260607.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260607.1':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260607.1':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260607.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260607.1':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260607.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260607.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260607.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260607.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260607.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260607.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260607.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260607.1
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   binary-extensions@2.3.0: {}
 
@@ -948,7 +1021,7 @@ snapshots:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.3
+      fsevents: 2.3.2
 
   deepmerge@4.3.1: {}
 
@@ -969,14 +1042,11 @@ snapshots:
   fsevents@2.3.2:
     optional: true
 
-  fsevents@2.3.3:
-    optional: true
-
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
 
-  glob-to-regex.js@1.0.1(tslib@2.8.1):
+  glob-to-regex.js@1.2.0(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
 
@@ -1004,20 +1074,20 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  memfs@4.57.3(tslib@2.8.1):
+  memfs@4.57.6(tslib@2.8.1):
     dependencies:
-      '@jsonjoy.com/fs-core': 4.57.3(tslib@2.8.1)
-      '@jsonjoy.com/fs-fsa': 4.57.3(tslib@2.8.1)
-      '@jsonjoy.com/fs-node': 4.57.3(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-builtins': 4.57.3(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-to-fsa': 4.57.3(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.57.3(tslib@2.8.1)
-      '@jsonjoy.com/fs-print': 4.57.3(tslib@2.8.1)
-      '@jsonjoy.com/fs-snapshot': 4.57.3(tslib@2.8.1)
-      '@jsonjoy.com/json-pack': 1.14.0(tslib@2.8.1)
+      '@jsonjoy.com/fs-core': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-fsa': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-node': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-to-fsa': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-print': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-snapshot': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/json-pack': 1.21.0(tslib@2.8.1)
       '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
-      glob-to-regex.js: 1.0.1(tslib@2.8.1)
-      thingies: 2.5.0(tslib@2.8.1)
+      glob-to-regex.js: 1.2.0(tslib@2.8.1)
+      thingies: 2.6.0(tslib@2.8.1)
       tree-dump: 1.1.0(tslib@2.8.1)
       tslib: 2.8.1
 
@@ -1025,7 +1095,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
 
@@ -1041,20 +1111,21 @@ snapshots:
 
   readdirp@3.6.0:
     dependencies:
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   reduce-configs@1.1.2: {}
 
-  rsbuild-plugin-dts@0.22.0(@rsbuild/core@2.0.9)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.22.0(@rsbuild/core@2.0.9)(@typescript/native-preview@7.0.0-dev.20260607.1)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.0.9
     optionalDependencies:
+      '@typescript/native-preview': 7.0.0-dev.20260607.1
       typescript: 6.0.3
 
   simple-git-hooks@2.13.1: {}
 
-  thingies@2.5.0(tslib@2.8.1):
+  thingies@2.6.0(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
 
@@ -1071,15 +1142,16 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  ts-checker-rspack-plugin@1.3.1(@rspack/core@2.0.5(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@6.0.3):
+  ts-checker-rspack-plugin@1.4.0(@rspack/core@2.0.5(@swc/helpers@0.5.23))(@typescript/native-preview@7.0.0-dev.20260607.1)(tslib@2.8.1)(typescript@6.0.3):
     dependencies:
-      '@rspack/lite-tapable': 1.1.0
+      '@rspack/lite-tapable': 1.1.2
       chokidar: 3.6.0
-      memfs: 4.57.3(tslib@2.8.1)
+      memfs: 4.57.6(tslib@2.8.1)
       picocolors: 1.1.1
       typescript: 6.0.3
     optionalDependencies:
       '@rspack/core': 2.0.5(@swc/helpers@0.5.23)
+      '@typescript/native-preview': 7.0.0-dev.20260607.1
     transitivePeerDependencies:
       - tslib
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 allowBuilds:
   core-js: false
   simple-git-hooks: false
+minimumReleaseAgeExclude:
+  - ts-checker-rspack-plugin@1.4.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,4 +2,4 @@ allowBuilds:
   core-js: false
   simple-git-hooks: false
 minimumReleaseAgeExclude:
-  - ts-checker-rspack-plugin@1.4.0
+  - ts-checker-rspack-plugin

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,17 +145,13 @@ export const pluginTypeCheck = (
             mergeFn: deepmerge,
           });
 
-          // Switch only the plugin-provided default path after user options are merged.
+          // Switch the plugin-provided TypeScript path for tsgo after user options are merged.
           if (
             mergedOptions.typescript &&
-            (mergedOptions.typescript.typescriptPath ===
-              projectTypescriptPath ||
-              mergedOptions.typescript.typescriptPath === projectTsgoPath)
+            mergedOptions.typescript.tsgo &&
+            mergedOptions.typescript.typescriptPath === projectTypescriptPath
           ) {
-            mergedOptions.typescript.typescriptPath = mergedOptions.typescript
-              .tsgo
-              ? projectTsgoPath
-              : projectTypescriptPath;
+            mergedOptions.typescript.typescriptPath = projectTsgoPath;
           }
 
           if (

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,36 +139,23 @@ export const pluginTypeCheck = (
             },
           };
 
-          let mergedOptions = defaultOptions;
-          let useDefaultTypescriptPath = true;
-          const tsCheckerOptionChain = Array.isArray(tsCheckerOptions)
-            ? tsCheckerOptions
-            : tsCheckerOptions
-              ? [tsCheckerOptions]
-              : [];
+          const mergedOptions = reduceConfigs({
+            initial: defaultOptions,
+            config: tsCheckerOptions,
+            mergeFn: deepmerge,
+          });
 
-          for (const config of tsCheckerOptionChain) {
-            mergedOptions = reduceConfigs({
-              initial: mergedOptions,
-              config,
-              mergeFn: deepmerge,
-            });
-
-            const { typescriptPath } = mergedOptions.typescript ?? {};
-            if (
-              typescriptPath &&
-              typescriptPath !== projectTypescriptPath &&
-              typescriptPath !== projectTsgoPath
-            ) {
-              useDefaultTypescriptPath = false;
-            }
-
-            if (mergedOptions.typescript && useDefaultTypescriptPath) {
-              mergedOptions.typescript.typescriptPath = mergedOptions.typescript
-                .tsgo
-                ? projectTsgoPath
-                : projectTypescriptPath;
-            }
+          // Switch only the plugin-provided default path after user options are merged.
+          if (
+            mergedOptions.typescript &&
+            (mergedOptions.typescript.typescriptPath ===
+              projectTypescriptPath ||
+              mergedOptions.typescript.typescriptPath === projectTsgoPath)
+          ) {
+            mergedOptions.typescript.typescriptPath = mergedOptions.typescript
+              .tsgo
+              ? projectTsgoPath
+              : projectTypescriptPath;
           }
 
           if (

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,19 @@ type TsCheckerOptions = NonNullable<
   ConstructorParameters<typeof TsCheckerRspackPlugin>[0]
 >;
 
+const resolveProjectPackage = (
+  packageName: string,
+  rootPath: string,
+): string | undefined => {
+  try {
+    return require.resolve(packageName, {
+      paths: [rootPath],
+    });
+  } catch {
+    return undefined;
+  }
+};
+
 export type PluginTypeCheckerOptions = {
   /**
    * Whether to enable TypeScript type checking.
@@ -77,24 +90,20 @@ export const pluginTypeCheck = (
           }
           checkedTsconfig.set(tsconfigPath, environment.name);
 
-          // use typescript of user project
-          let typescriptPath: string;
-          try {
-            typescriptPath = require.resolve('typescript', {
-              paths: [api.context.rootPath],
-            });
-          } catch {
-            logger.warn(
-              '"typescript" is not found in current project, Type checker will not work.',
-            );
-            return;
-          }
-
           const { references } = json5.parse(
             fs.readFileSync(tsconfigPath, 'utf-8'),
           );
           const useReference =
             Array.isArray(references) && references.length > 0;
+          // use typescript of user project
+          const projectTypescriptPath = resolveProjectPackage(
+            'typescript',
+            api.context.rootPath,
+          );
+          const projectTsgoPath = resolveProjectPackage(
+            '@typescript/native-preview/package.json',
+            api.context.rootPath,
+          );
 
           const defaultOptions: TsCheckerOptions = {
             typescript: {
@@ -107,8 +116,9 @@ export const pluginTypeCheck = (
               memoryLimit: 8192,
               // use tsconfig of user project
               configFile: tsconfigPath,
+              tsgo: false,
               // use typescript of user project
-              typescriptPath,
+              typescriptPath: projectTypescriptPath,
             },
             issue: {
               // ignore types errors from node_modules
@@ -129,11 +139,50 @@ export const pluginTypeCheck = (
             },
           };
 
-          const mergedOptions = reduceConfigs({
-            initial: defaultOptions,
-            config: tsCheckerOptions,
-            mergeFn: deepmerge,
-          });
+          let mergedOptions = defaultOptions;
+          let useDefaultTypescriptPath = true;
+          const tsCheckerOptionChain = Array.isArray(tsCheckerOptions)
+            ? tsCheckerOptions
+            : tsCheckerOptions
+              ? [tsCheckerOptions]
+              : [];
+
+          for (const config of tsCheckerOptionChain) {
+            mergedOptions = reduceConfigs({
+              initial: mergedOptions,
+              config,
+              mergeFn: deepmerge,
+            });
+
+            const { typescriptPath } = mergedOptions.typescript ?? {};
+            if (
+              typescriptPath &&
+              typescriptPath !== projectTypescriptPath &&
+              typescriptPath !== projectTsgoPath
+            ) {
+              useDefaultTypescriptPath = false;
+            }
+
+            if (mergedOptions.typescript && useDefaultTypescriptPath) {
+              mergedOptions.typescript.typescriptPath = mergedOptions.typescript
+                .tsgo
+                ? projectTsgoPath
+                : projectTypescriptPath;
+            }
+          }
+
+          if (
+            mergedOptions.typescript &&
+            !mergedOptions.typescript.typescriptPath
+          ) {
+            const typeCheckerPackage = mergedOptions.typescript.tsgo
+              ? '@typescript/native-preview'
+              : 'typescript';
+            logger.warn(
+              `"${typeCheckerPackage}" is not found in current project, Type checker will not work.`,
+            );
+            return;
+          }
 
           if (isProd) {
             logger.info('Type checker is enabled. It may take some time.');

--- a/test/typescript-go/index.test.ts
+++ b/test/typescript-go/index.test.ts
@@ -69,33 +69,3 @@ test('should respect issue exclude when using typescript-go', async () => {
     restore();
   }
 });
-
-test('should provide native preview path in default options when using typescript-go', async () => {
-  let typescriptPath: string | undefined;
-
-  const rsbuild = await createRsbuild({
-    cwd: __dirname,
-    rsbuildConfig: {
-      plugins: [
-        pluginTypeCheck({
-          tsCheckerOptions: [
-            {
-              typescript: {
-                tsgo: true,
-              },
-            },
-            (options) => {
-              typescriptPath = options.typescript?.typescriptPath;
-              return options;
-            },
-          ],
-        }),
-      ],
-    },
-  });
-
-  await expect(rsbuild.build()).rejects.toThrowError('build failed');
-  expect(typescriptPath?.replace(/\\/g, '/')).toContain(
-    '/@typescript/native-preview/package.json',
-  );
-});

--- a/test/typescript-go/index.test.ts
+++ b/test/typescript-go/index.test.ts
@@ -1,0 +1,101 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, test } from '@playwright/test';
+import { createRsbuild } from '@rsbuild/core';
+import { pluginTypeCheck } from '@rsbuild/plugin-type-check';
+import { proxyConsole } from '../helper';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+test('should throw error and format diagnostics when using typescript-go', async () => {
+  const { logs, restore } = proxyConsole();
+
+  try {
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
+      rsbuildConfig: {
+        plugins: [
+          pluginTypeCheck({
+            tsCheckerOptions: {
+              typescript: {
+                tsgo: true,
+              },
+            },
+          }),
+        ],
+      },
+    });
+
+    await expect(rsbuild.build()).rejects.toThrowError('build failed');
+
+    expect(logs.some((log) => log.includes('TS2345'))).toBeTruthy();
+    expect(
+      logs.some((log) =>
+        log.includes(
+          `Argument of type 'string' is not assignable to parameter of type 'number'.`,
+        ),
+      ),
+    ).toBeTruthy();
+  } finally {
+    restore();
+  }
+});
+
+test('should respect issue exclude when using typescript-go', async () => {
+  const { logs, restore } = proxyConsole();
+
+  try {
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
+      rsbuildConfig: {
+        plugins: [
+          pluginTypeCheck({
+            tsCheckerOptions: {
+              issue: {
+                exclude: [{ code: 'TS2345' }],
+              },
+              typescript: {
+                tsgo: true,
+              },
+            },
+          }),
+        ],
+      },
+    });
+
+    await expect(rsbuild.build()).resolves.toBeTruthy();
+    expect(logs.some((log) => log.includes('TS2345'))).toBeFalsy();
+  } finally {
+    restore();
+  }
+});
+
+test('should provide native preview path in default options when using typescript-go', async () => {
+  let typescriptPath: string | undefined;
+
+  const rsbuild = await createRsbuild({
+    cwd: __dirname,
+    rsbuildConfig: {
+      plugins: [
+        pluginTypeCheck({
+          tsCheckerOptions: [
+            {
+              typescript: {
+                tsgo: true,
+              },
+            },
+            (options) => {
+              typescriptPath = options.typescript?.typescriptPath;
+              return options;
+            },
+          ],
+        }),
+      ],
+    },
+  });
+
+  await expect(rsbuild.build()).rejects.toThrowError('build failed');
+  expect(typescriptPath?.replace(/\\/g, '/')).toContain(
+    '/@typescript/native-preview/package.json',
+  );
+});

--- a/test/typescript-go/src/index.ts
+++ b/test/typescript-go/src/index.ts
@@ -1,0 +1,6 @@
+const add = (a: number, b: number) => a + b;
+
+// this is a type error
+const res = add(1, '2');
+
+console.log('res', res);

--- a/test/typescript-go/tsconfig.json
+++ b/test/typescript-go/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["DOM", "ESNext"],
+    "module": "ES2020",
+    "strict": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "types": []
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

This PR adds experimental TypeScript Go support by resolving `@typescript/native-preview/package.json` when `typescript.tsgo` is enabled, while preserving the regular project TypeScript path for non-tsgo checks.

## Related Links

- https://github.com/rstackjs/ts-checker-rspack-plugin/releases/tag/v1.4.0
- https://github.com/rstackjs/ts-checker-rspack-plugin#typescript-go-support