### PR TITLE
fix: refine tsgo docs and type checker log

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ const defaultOptions = {
     memoryLimit: 8192,
     // use tsconfig of user project
     configFile: tsconfigPath,
+    // use TypeScript checker by default
     tsgo: false,
     // use typescript of user project
     typescriptPath: tsgo

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,7 +168,11 @@ export const pluginTypeCheck = (
           }
 
           if (isProd) {
-            logger.info('Type checker is enabled. It may take some time.');
+            logger.info(
+              mergedOptions.typescript?.tsgo
+                ? 'Type checker is enabled.'
+                : 'Type checker is enabled. It may take some time. You can enable `typescript.tsgo` to speed up type checking.',
+            );
           }
 
           chain


### PR DESCRIPTION
This PR clarifies in the README default options snippet that the regular TypeScript checker is used by default. It also refines the production type-checker log so both regular TypeScript and `tsgo` modes still announce that type checking is enabled, while only the regular TypeScript path keeps the `It may take some time` message and suggests enabling `typescript.tsgo` for faster checks.