### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@rsbuild/plugin-type-check",
   "version": "1.4.0",
   "repository": "https://github.com/rstackjs/rsbuild-plugin-type-check",
+  "homepage": "https://github.com/rstackjs/rsbuild-plugin-type-check#readme",
+  "bugs": {
+    "url": "https://github.com/rstackjs/rsbuild-plugin-type-check/issues"
+  },
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- add npm `homepage` metadata pointing to the README
- add npm `bugs.url` metadata pointing to the GitHub issue tracker

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json OK')"`
- `git diff --check`
