### PR TITLE
feat: support TypeScript 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,12 +117,13 @@ const defaultOptions = {
     memoryLimit: 8192,
     // use tsconfig of user project
     configFile: tsconfigPath,
-    // use TypeScript checker by default
-    tsgo: false,
-    // use typescript of user project
-    typescriptPath: tsgo
-      ? require.resolve('@typescript/native-preview/package.json')
-      : require.resolve('typescript'),
+    // use TypeScript Go automatically when TypeScript 7+ is installed
+    tsgo: typescriptMajorVersion >= 7 ? true : false,
+    // use TypeScript of user project
+    typescriptPath:
+      typescriptMajorVersion >= 7
+        ? require.resolve('typescript/package.json')
+        : require.resolve('typescript'),
   },
   issue: {
     // ignore types errors from node_modules
@@ -142,9 +143,22 @@ const defaultOptions = {
 
 #### TypeScript Go support
 
-TypeScript Go support is powered by `ts-checker-rspack-plugin`'s experimental, CLI-based integration for [typescript-go](https://github.com/microsoft/typescript-go). It runs the `tsgo` binary for type checking and can reduce type-checking time by about 5-10x.
+TypeScript Go support is powered by `ts-checker-rspack-plugin`'s experimental, CLI-based integration for [typescript-go](https://github.com/microsoft/typescript-go). It runs the TypeScript Go checker binary for type checking and can reduce type-checking time by about 5-10x.
 
-To enable it, install `@typescript/native-preview` and set `typescript.tsgo` to `true`:
+Install TypeScript 7.0 RC to use TypeScript Go automatically:
+
+```sh
+# with npm
+npm install -D typescript@rc
+
+# with yarn
+yarn add -D typescript@rc
+
+# with pnpm
+pnpm add -D typescript@rc
+```
+
+You can also install `@typescript/native-preview` and set `typescript.tsgo` to `true`:
 
 ```ts
 pluginTypeCheck({
@@ -156,7 +170,9 @@ pluginTypeCheck({
 });
 ```
 
-When `tsgo` is enabled, the default `typescript.typescriptPath` resolves to `@typescript/native-preview/package.json`. If you set `typescript.typescriptPath` manually in `tsgo` mode, it must be an absolute path to `@typescript/native-preview/package.json`.
+When `tsgo` is enabled, `typescript.typescriptPath` must point to an absolute `typescript/package.json` path from TypeScript 7+ or `@typescript/native-preview/package.json`. If TypeScript 7+ is not installed, the default path falls back to `@typescript/native-preview/package.json`.
+
+> The `@typescript/native-preview` usage is deprecated and kept only for compatibility. We recommend installing `typescript@rc` to use `tsgo`.
 
 For supported options and limitations, see [ts-checker-rspack-plugin - TypeScript Go support](https://github.com/rstackjs/ts-checker-rspack-plugin#typescript-go-support).
 

--- a/README.md
+++ b/README.md
@@ -117,13 +117,8 @@ const defaultOptions = {
     memoryLimit: 8192,
     // use tsconfig of user project
     configFile: tsconfigPath,
-    // use TypeScript Go automatically when TypeScript 7+ is installed
-    tsgo: typescriptMajorVersion >= 7 ? true : false,
-    // use TypeScript of user project
-    typescriptPath:
-      typescriptMajorVersion >= 7
-        ? require.resolve('typescript/package.json')
-        : require.resolve('typescript'),
+    // resolve the default TypeScript package from user project
+    resolveRoot: api.context.rootPath,
   },
   issue: {
     // ignore types errors from node_modules
@@ -135,7 +130,11 @@ const defaultOptions = {
       // we only want to display error messages
     },
     error(message: string) {
-      console.error(message.replace(/ERROR/g, 'Type Error'));
+      console.error(
+        message
+          .replace(/ERROR/g, 'Type Error')
+          .replace(/WARNING/g, 'Type Warning'),
+      );
     },
   },
 };
@@ -170,7 +169,7 @@ pluginTypeCheck({
 });
 ```
 
-When `tsgo` is enabled, `typescript.typescriptPath` must point to an absolute `typescript/package.json` path from TypeScript 7+ or `@typescript/native-preview/package.json`. If TypeScript 7+ is not installed, the default path falls back to `@typescript/native-preview/package.json`.
+When `tsgo` is enabled and `typescript.typescriptPath` is set manually, it must point to an absolute `typescript/package.json` path from TypeScript 7+ or `@typescript/native-preview/package.json`.
 
 > The `@typescript/native-preview` usage is deprecated and kept only for compatibility. We recommend installing `typescript@rc` to use `tsgo`.
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "deepmerge": "^4.3.1",
     "json5": "^2.2.3",
     "reduce-configs": "^1.1.2",
-    "ts-checker-rspack-plugin": "^1.4.0"
+    "ts-checker-rspack-plugin": "^1.5.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "deepmerge": "^4.3.1",
     "json5": "^2.2.3",
     "reduce-configs": "^1.1.2",
-    "ts-checker-rspack-plugin": "^1.5.0"
+    "ts-checker-rspack-plugin": "^1.5.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2
       ts-checker-rspack-plugin:
-        specifier: ^1.4.0
-        version: 1.4.0(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@typescript/native-preview@7.0.0-dev.20260624.1)(tslib@2.8.1)(typescript@6.0.3)
+        specifier: ^1.5.0
+        version: 1.5.1(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@typescript/native-preview@7.0.0-dev.20260624.1)(tslib@2.8.1)(typescript@6.0.3)
     devDependencies:
       '@playwright/test':
         specifier: ^1.61.1
@@ -167,50 +167,50 @@ packages:
     peerDependencies:
       tslib: '2'
 
-  '@jsonjoy.com/fs-core@4.57.6':
-    resolution: {integrity: sha512-uI++Wx6VkBJqVmkb4ZeExwAVpZiA2Do5NrEtXoDk0Pdvce3ytFXJoviT1sLOj16+qDIMnD5nWPfOhVpnDmRJKg==}
+  '@jsonjoy.com/fs-core@4.57.8':
+    resolution: {integrity: sha512-YzVbwggV9452VCeHgo0bjsTaUt1O7JE0XpEsPar93nn/+RAwXk0mb1Y+f5EDJ3TRtRCFe+Ck5RuojdfB4jeHVw==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
 
-  '@jsonjoy.com/fs-fsa@4.57.6':
-    resolution: {integrity: sha512-pKkw/yC5CzSZKhIIUIsH1przOa+K5jGmZIg1sWaSF24JojyrUFbjcQv7QrcGAudriei6HQ6R0BFj+V8NbQinJw==}
+  '@jsonjoy.com/fs-fsa@4.57.8':
+    resolution: {integrity: sha512-vmClyvCQMxgqz7uamDiGtRfp4MjzOznk3pcQjCxlIwJcw7TWeyr+bF30hI0x8NxdtNOGMg1pHM74VDIXOeyjuw==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
 
-  '@jsonjoy.com/fs-node-builtins@4.57.6':
-    resolution: {integrity: sha512-V4DgEFT3Cg5S9fCMOZSCVdTxdJWWLBO0WnAazV7hnCM96u5zXHyW/ubDAfcSVwqjkMJ50W1Y44IXtxRoIwaCVg==}
+  '@jsonjoy.com/fs-node-builtins@4.57.8':
+    resolution: {integrity: sha512-mxXSXw8zZwRVakcjLqR2I/psy4gURFSASZS10kKJ2kJw05GC2nXGroGrWVHxwgkxXgQLsFQnB74QaLzsxzdL/w==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
 
-  '@jsonjoy.com/fs-node-to-fsa@4.57.6':
-    resolution: {integrity: sha512-+JptNw3iifihxH2rEXrninDzX4FFVW8JD/wPR8GbJPAeL9CQUSblrlumOPB5gZuS7tYRX+PJPLtT7XzKoRhv/Q==}
+  '@jsonjoy.com/fs-node-to-fsa@4.57.8':
+    resolution: {integrity: sha512-AWZcT/4+H+iDl4XCukbXrarvwEgOrf/prFI5/7eg4ix9FxqVsZysIDJd1Kjd+AjlCeHKHJOaRqjLd5HiGSCJEw==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
 
-  '@jsonjoy.com/fs-node-utils@4.57.6':
-    resolution: {integrity: sha512-foyUrfS7WmYEUzqYXSNxmJBcSj04TABrkpFabwO9SCDCpVCfJ+qG+2sk5FjfiflG2n0SDFZDCJ6vYlJAEpxJFg==}
+  '@jsonjoy.com/fs-node-utils@4.57.8':
+    resolution: {integrity: sha512-E/bJ7sQAb4pu9nbeJhbULU3WnqWrswte4N9Js/oHt7aHB746S8/XBqKlcbrqIgnD3095XluovNEZuu5ONT230g==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
 
-  '@jsonjoy.com/fs-node@4.57.6':
-    resolution: {integrity: sha512-Kbn1jdkvDN4F2+BhoB6mMu7NCbhP0bgA5NcI1aJj/Q5UcU+I1JLLW+dEQean33iV4tXv35AzBVKPICnDltBpxw==}
+  '@jsonjoy.com/fs-node@4.57.8':
+    resolution: {integrity: sha512-IPEOlDYSnTDYpjQlQg2F8h+eqxKQN3sdbroI0WrteRiQZ462HzVpBo9ZZX485njz4nAacoe3fd4iDiIhk+k5Hg==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
 
-  '@jsonjoy.com/fs-print@4.57.6':
-    resolution: {integrity: sha512-96eAn4Dudtt67LTeuU47yUD+pg9/G/oKpI10zei9ljk3X3WK4lYKc+n3cpaPCAbKPzoyfxl0mXm8f8Y7BOSFXw==}
+  '@jsonjoy.com/fs-print@4.57.8':
+    resolution: {integrity: sha512-DfzhOBpmvNu5P/KSe4NNQaOnvNliTdcf0qrh/4EReErF/XUQXYkd0vZl/OiJCm/qjEEo8DWRstliw2/JNS84dA==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
 
-  '@jsonjoy.com/fs-snapshot@4.57.6':
-    resolution: {integrity: sha512-V57CMzbOgTzUWGOWQ8GzHQdpJP6JnrYVNCtTBNxVYEnlVRvo4uEJqHhtAT8vhDFrIuJOXLrTL1Fki4h5oI7xxg==}
+  '@jsonjoy.com/fs-snapshot@4.57.8':
+    resolution: {integrity: sha512-L+eqKaWOHLDaiMv1dh/EWQ4hA+o6xAhWSumTo3Teg7OM18jU/KE13/e8Mfal+eAZ/pSl4wIhKHcDiwapJzC8Wg==}
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
@@ -548,8 +548,8 @@ packages:
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
-  memfs@4.57.6:
-    resolution: {integrity: sha512-WQK+DGjKCnPdpSyJUXphz+COF2uEhhsxQ3VIWBSbzpbbXuch3h4FePMqXrXGdLjsTgo4JFzBFsP6AWd9pVazGw==}
+  memfs@4.57.8:
+    resolution: {integrity: sha512-bApYhn8BLpFAnAQmFfEl/NPN+8qx5Ar3V4Qt3ek23mVwBEElzV7c6XoPkb/PCG8ZFpowCEpHcPwMFTwHS7tSMA==}
     peerDependencies:
       tslib: '2'
 
@@ -626,8 +626,8 @@ packages:
     peerDependencies:
       tslib: '2'
 
-  ts-checker-rspack-plugin@1.4.0:
-    resolution: {integrity: sha512-xPBPe6n9XZW9vMw4PFJLZFY372rejKK8UFC12i33J+yJK+fmsQQ4k9eoOlbLE0zC6vftyKDhvfMF3RyMFFTOZw==}
+  ts-checker-rspack-plugin@1.5.1:
+    resolution: {integrity: sha512-h0jF3PAIrG+UA2nZ2OPUEt0NywkpiJkydkoVg/Kd1OFPFlrayNBJoSP0zeNPUpdsFEt7ICX1BjENCfOH9nmMyA==}
     peerDependencies:
       '@rspack/core': ^1.0.0 || ^2.0.0
       '@typescript/native-preview': ^7.0.0-0
@@ -737,58 +737,58 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@jsonjoy.com/fs-core@4.57.6(tslib@2.8.1)':
+  '@jsonjoy.com/fs-core@4.57.8(tslib@2.8.1)':
     dependencies:
-      '@jsonjoy.com/fs-node-builtins': 4.57.6(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.8(tslib@2.8.1)
       thingies: 2.6.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@jsonjoy.com/fs-fsa@4.57.6(tslib@2.8.1)':
+  '@jsonjoy.com/fs-fsa@4.57.8(tslib@2.8.1)':
     dependencies:
-      '@jsonjoy.com/fs-core': 4.57.6(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-builtins': 4.57.6(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-core': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.8(tslib@2.8.1)
       thingies: 2.6.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@jsonjoy.com/fs-node-builtins@4.57.6(tslib@2.8.1)':
+  '@jsonjoy.com/fs-node-builtins@4.57.8(tslib@2.8.1)':
     dependencies:
       tslib: 2.8.1
 
-  '@jsonjoy.com/fs-node-to-fsa@4.57.6(tslib@2.8.1)':
+  '@jsonjoy.com/fs-node-to-fsa@4.57.8(tslib@2.8.1)':
     dependencies:
-      '@jsonjoy.com/fs-fsa': 4.57.6(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-builtins': 4.57.6(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-fsa': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.8(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@jsonjoy.com/fs-node-utils@4.57.6(tslib@2.8.1)':
+  '@jsonjoy.com/fs-node-utils@4.57.8(tslib@2.8.1)':
     dependencies:
-      '@jsonjoy.com/fs-node-builtins': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.8(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@jsonjoy.com/fs-node@4.57.6(tslib@2.8.1)':
+  '@jsonjoy.com/fs-node@4.57.8(tslib@2.8.1)':
     dependencies:
-      '@jsonjoy.com/fs-core': 4.57.6(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-builtins': 4.57.6(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.57.6(tslib@2.8.1)
-      '@jsonjoy.com/fs-print': 4.57.6(tslib@2.8.1)
-      '@jsonjoy.com/fs-snapshot': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-core': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-print': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-snapshot': 4.57.8(tslib@2.8.1)
       glob-to-regex.js: 1.2.0(tslib@2.8.1)
       thingies: 2.6.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@jsonjoy.com/fs-print@4.57.6(tslib@2.8.1)':
+  '@jsonjoy.com/fs-print@4.57.8(tslib@2.8.1)':
     dependencies:
-      '@jsonjoy.com/fs-node-utils': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.8(tslib@2.8.1)
       tree-dump: 1.1.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@jsonjoy.com/fs-snapshot@4.57.6(tslib@2.8.1)':
+  '@jsonjoy.com/fs-snapshot@4.57.8(tslib@2.8.1)':
     dependencies:
       '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.8(tslib@2.8.1)
       '@jsonjoy.com/json-pack': 17.67.0(tslib@2.8.1)
       '@jsonjoy.com/util': 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
@@ -1088,16 +1088,16 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  memfs@4.57.6(tslib@2.8.1):
+  memfs@4.57.8(tslib@2.8.1):
     dependencies:
-      '@jsonjoy.com/fs-core': 4.57.6(tslib@2.8.1)
-      '@jsonjoy.com/fs-fsa': 4.57.6(tslib@2.8.1)
-      '@jsonjoy.com/fs-node': 4.57.6(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-builtins': 4.57.6(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-to-fsa': 4.57.6(tslib@2.8.1)
-      '@jsonjoy.com/fs-node-utils': 4.57.6(tslib@2.8.1)
-      '@jsonjoy.com/fs-print': 4.57.6(tslib@2.8.1)
-      '@jsonjoy.com/fs-snapshot': 4.57.6(tslib@2.8.1)
+      '@jsonjoy.com/fs-core': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-fsa': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-node': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-builtins': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-to-fsa': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-node-utils': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-print': 4.57.8(tslib@2.8.1)
+      '@jsonjoy.com/fs-snapshot': 4.57.8(tslib@2.8.1)
       '@jsonjoy.com/json-pack': 1.21.0(tslib@2.8.1)
       '@jsonjoy.com/util': 1.9.0(tslib@2.8.1)
       glob-to-regex.js: 1.2.0(tslib@2.8.1)
@@ -1151,11 +1151,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  ts-checker-rspack-plugin@1.4.0(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@typescript/native-preview@7.0.0-dev.20260624.1)(tslib@2.8.1)(typescript@6.0.3):
+  ts-checker-rspack-plugin@1.5.1(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@typescript/native-preview@7.0.0-dev.20260624.1)(tslib@2.8.1)(typescript@6.0.3):
     dependencies:
       '@rspack/lite-tapable': 1.1.2
       chokidar: 3.6.0
-      memfs: 4.57.6(tslib@2.8.1)
+      memfs: 4.57.8(tslib@2.8.1)
       picocolors: 1.1.1
       typescript: 6.0.3
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,15 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  test/typescript-v7-rc:
+    devDependencies:
+      '@rsbuild/plugin-type-check':
+        specifier: workspace:*
+        version: link:../..
+      typescript:
+        specifier: 7.0.1-rc
+        version: 7.0.1-rc
+
 packages:
 
   '@ast-grep/napi-darwin-arm64@0.37.0':
@@ -474,6 +483,90 @@ packages:
     engines: {node: '>=16.20.0'}
     hasBin: true
 
+  '@typescript/typescript-darwin-arm64@7.0.1-rc':
+    resolution: {integrity: sha512-Slc0yTftT2F/uGDmtPst8ijydneL6uZaLEyr2UjahxZpbhTjHFBJ5agXtVz/TL4A+ldxzjzj+E8QtLZlh/5mXw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.1-rc':
+    resolution: {integrity: sha512-h68iFW/LbA1/BsGgSRGFw981/3s1f/rY27YrmeZNuN+ly7dI+fiDduwT9ZT9866x2onoKNRq7PTyxSKyKDzfAQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-linux-arm64@7.0.1-rc':
+    resolution: {integrity: sha512-N46pRihK3t5zD5MUtTQcdmQUqr1WI4U2nxno1gLwOtRSsB4krFkRjPHcQNG7h2DtRkX64rQiReX6WKwg2wprMA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.1-rc':
+    resolution: {integrity: sha512-0FQspOb5UsQ4tQKvWgUO3pS9OIWkP7/8dPRWq+CRazJUeQZ4LBjtYK52jg5iIOrvItrVl2CwvRtrU3/9OihwJg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.1-rc':
+    resolution: {integrity: sha512-SUmwfVBEv6A2Ld0eWfcvW0FqrgemfQL8jFGOmV1qYxsDqumjE5DekHXqbstgmbE4SHr4rrjHjvmuGCY+kTH/vw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.1-rc':
+    resolution: {integrity: sha512-rxeqnNnGiYzv/LlPHi/3+4p0ooR1cNJLjRIHXKovtiVmxXGJq6gtw8VSpbHuWPekyFMXgIAoLCZN0SQ51rAALQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.1-rc':
+    resolution: {integrity: sha512-RYWCHCiPypxajdRHM2CNK/eM22e4Ex5TTjV2pXf7PTtBowGr0xX8i8kIMknyZS0LX2QfleYHouaoMVsFDSle3g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.1-rc':
+    resolution: {integrity: sha512-PfLJSu0JzroDkqw2m4nqflPEcn8yev0m/vHFQlY9EzHorzjR6QG0wL8AJHvnD1e6h1s76AZngJ5u+z1K/D/HKw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.1-rc':
+    resolution: {integrity: sha512-FfbPxH3dTfp8yVIaNM7bdWTixXuyxpzoemluqcqMROSIz+ImpCG3Q9HO9Ptzp9/giv+P9YYEnCMSXh61migj2w==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.1-rc':
+    resolution: {integrity: sha512-FzdTfSzhRYb6hlav6K3cI5RVgcvCTvNAu/vc+t7B6AmZkThQ+t/1ntnvT5fnHmY1Az2RIBw7/b+qtCEG61HJTQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.1-rc':
+    resolution: {integrity: sha512-WJ7NYgO2mHmLUkI/tZ+hl8lFd26QPJqO8ONOHNuYbdsybLvSB6B6sep222JIVrOfPRDGvFinbGGB+l3m1FWRWA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.1-rc':
+    resolution: {integrity: sha512-UYjDeUxd765V9qcwlUPk4pEXyL0i3G76CJm9baK4i99u1pGO1psf3nXDw4MMmElVOPvGbZag99ZR/O59E2OX6w==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.1-rc':
+    resolution: {integrity: sha512-KzXzFSXZOm7zvEt2Aw0MsB2LbTL88znAiVqTDNAOHdlEb7brgmUQh/X2wM/8Be+N0fjEqWKl65cBKNwpWEbJiw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.1-rc':
+    resolution: {integrity: sha512-98R3+OqDr/r0/PLWEoXu88AE0lGVLNd335Ew8ONgzK1JWkNs4ou/5BGt3Or1ij4iXjH+c7PRL+jFjCbtWze+EA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -644,6 +737,11 @@ packages:
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@7.0.1-rc:
+    resolution: {integrity: sha512-drEP77wK7CCDlPfXZH4e008UUQOsw1DFmHmZOZjuNA+yoDLLnSNMZRXi90NbV/1LVo7SbNLq1bs3jjvk49TEqQ==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   undici-types@7.16.0:
@@ -1018,6 +1116,48 @@ snapshots:
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260624.1
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260624.1
 
+  '@typescript/typescript-darwin-arm64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.1-rc':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.1-rc':
+    optional: true
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
@@ -1167,6 +1307,23 @@ snapshots:
   tslib@2.8.1: {}
 
   typescript@6.0.3: {}
+
+  typescript@7.0.1-rc:
+    optionalDependencies:
+      '@typescript/typescript-darwin-arm64': 7.0.1-rc
+      '@typescript/typescript-darwin-x64': 7.0.1-rc
+      '@typescript/typescript-linux-arm64': 7.0.1-rc
+      '@typescript/typescript-linux-mips64el': 7.0.1-rc
+      '@typescript/typescript-linux-ppc64': 7.0.1-rc
+      '@typescript/typescript-linux-riscv64': 7.0.1-rc
+      '@typescript/typescript-linux-s390x': 7.0.1-rc
+      '@typescript/typescript-linux-x64': 7.0.1-rc
+      '@typescript/typescript-netbsd-arm64': 7.0.1-rc
+      '@typescript/typescript-netbsd-x64': 7.0.1-rc
+      '@typescript/typescript-openbsd-x64': 7.0.1-rc
+      '@typescript/typescript-sunos-x64': 7.0.1-rc
+      '@typescript/typescript-win32-arm64': 7.0.1-rc
+      '@typescript/typescript-win32-x64': 7.0.1-rc
 
   undici-types@7.16.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2
       ts-checker-rspack-plugin:
-        specifier: ^1.5.0
+        specifier: ^1.5.1
         version: 1.5.1(@rspack/core@2.0.8(@swc/helpers@0.5.23))(@typescript/native-preview@7.0.0-dev.20260624.1)(tslib@2.8.1)(typescript@6.0.3)
     devDependencies:
       '@playwright/test':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
+packages:
+  - .
+  - test/typescript-v7-rc
+
 allowBuilds:
   core-js: false
   simple-git-hooks: false

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,6 @@ type ProjectTypeScriptPaths = {
   packageJsonPath?: string;
   previewPackageJsonPath?: string;
   supportsTsgo: boolean;
-  defaultPath?: string;
 };
 
 const TYPESCRIPT_PACKAGE = 'typescript';
@@ -85,11 +84,10 @@ const resolveProjectTypeScriptPaths = (
     packageJsonPath,
     previewPackageJsonPath,
     supportsTsgo,
-    defaultPath: supportsTsgo ? packageJsonPath : typescriptPath,
   };
 };
 
-const applyTypeScriptPathCompat = (
+const applyTypeScriptDefaults = (
   typescriptOptions: TypeScriptOptions | undefined,
   projectPaths: ProjectTypeScriptPaths,
 ): boolean => {
@@ -101,38 +99,34 @@ const applyTypeScriptPathCompat = (
   const normalizedOptions =
     typescriptOptions as TypeScriptOptionsWithTsgoPackage;
 
-  if (
-    typescriptOptions.tsgo === false &&
-    configuredPath === projectPaths.packageJsonPath
-  ) {
-    typescriptOptions.typescriptPath = projectPaths.typescriptPath;
-  } else if (
-    typescriptOptions.tsgo !== false &&
-    projectPaths.supportsTsgo &&
-    (configuredPath === projectPaths.typescriptPath ||
-      configuredPath === projectPaths.packageJsonPath ||
-      configuredPath === TYPESCRIPT_PACKAGE ||
-      configuredPath === TYPESCRIPT_PACKAGE_JSON)
-  ) {
-    typescriptOptions.typescriptPath = projectPaths.packageJsonPath;
-    typescriptOptions.tsgo ??= true;
-    normalizedOptions.tsgoPackage ??= 'typescript';
-  } else if (
-    typescriptOptions.tsgo &&
-    !projectPaths.supportsTsgo &&
-    (!configuredPath ||
-      configuredPath === projectPaths.typescriptPath ||
-      configuredPath === TYPESCRIPT_PACKAGE)
-  ) {
-    typescriptOptions.typescriptPath = projectPaths.previewPackageJsonPath;
-    normalizedOptions.tsgoPackage ??= 'preview';
+  if (configuredPath) {
+    return (
+      Boolean(typescriptOptions.tsgo) ||
+      (typescriptOptions.tsgo !== false &&
+        isTypeScriptGoSupportedPackage(configuredPath))
+    );
   }
 
-  return (
-    Boolean(typescriptOptions.tsgo) ||
-    (typescriptOptions.tsgo !== false &&
-      isTypeScriptGoSupportedPackage(typescriptOptions.typescriptPath))
-  );
+  if (typescriptOptions.tsgo === false) {
+    typescriptOptions.typescriptPath = projectPaths.typescriptPath;
+    return false;
+  }
+
+  if (projectPaths.supportsTsgo) {
+    typescriptOptions.typescriptPath = projectPaths.packageJsonPath;
+    typescriptOptions.tsgo = true;
+    normalizedOptions.tsgoPackage = 'typescript';
+    return true;
+  }
+
+  if (typescriptOptions.tsgo === true) {
+    typescriptOptions.typescriptPath = projectPaths.previewPackageJsonPath;
+    normalizedOptions.tsgoPackage = 'preview';
+    return true;
+  }
+
+  typescriptOptions.typescriptPath = projectPaths.typescriptPath;
+  return false;
 };
 
 export type PluginTypeCheckerOptions = {
@@ -220,9 +214,6 @@ export const pluginTypeCheck = (
               memoryLimit: 8192,
               // use tsconfig of user project
               configFile: tsconfigPath,
-              // use TypeScript of user project.
-              // TypeScript 7+ must point to package.json.
-              typescriptPath: projectTypescriptPaths.defaultPath,
             },
             issue: {
               // ignore types errors from node_modules
@@ -250,7 +241,7 @@ export const pluginTypeCheck = (
           });
 
           const typescriptOptions = mergedOptions.typescript;
-          const isTypeScriptGoEnabled = applyTypeScriptPathCompat(
+          const isTypeScriptGoEnabled = applyTypeScriptDefaults(
             typescriptOptions,
             projectTypescriptPaths,
           );

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,20 @@ const require = createRequire(import.meta.url);
 type TsCheckerOptions = NonNullable<
   ConstructorParameters<typeof TsCheckerRspackPlugin>[0]
 >;
+type TypeScriptOptions = NonNullable<TsCheckerOptions['typescript']>;
+
+type ProjectTypeScriptPaths = {
+  typescriptPath?: string;
+  packageJsonPath?: string;
+  previewPackageJsonPath?: string;
+  supportsTsgo: boolean;
+  defaultPath?: string;
+};
+
+const TYPESCRIPT_PACKAGE = 'typescript';
+const TYPESCRIPT_PACKAGE_JSON = `${TYPESCRIPT_PACKAGE}/package.json`;
+const TYPESCRIPT_PREVIEW_PACKAGE = '@typescript/native-preview';
+const TYPESCRIPT_PREVIEW_PACKAGE_JSON = `${TYPESCRIPT_PREVIEW_PACKAGE}/package.json`;
 
 const resolveProjectPackage = (
   packageName: string,
@@ -23,6 +37,93 @@ const resolveProjectPackage = (
   } catch {
     return undefined;
   }
+};
+
+const isTypeScriptGoSupportedPackage = (
+  packageJsonPath: string | undefined,
+): boolean => {
+  if (!packageJsonPath) {
+    return false;
+  }
+
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+    const version =
+      typeof packageJson.version === 'string' ? packageJson.version : '';
+    const versionMatch = version.match(/^(\d+)\.(\d+)(?:\.|$|-)/);
+
+    return (
+      packageJson.name === TYPESCRIPT_PACKAGE &&
+      Boolean(versionMatch) &&
+      Number(versionMatch[1]) >= 7
+    );
+  } catch {
+    return false;
+  }
+};
+
+const resolveProjectTypeScriptPaths = (
+  rootPath: string,
+): ProjectTypeScriptPaths => {
+  const typescriptPath = resolveProjectPackage(TYPESCRIPT_PACKAGE, rootPath);
+  const packageJsonPath = resolveProjectPackage(
+    TYPESCRIPT_PACKAGE_JSON,
+    rootPath,
+  );
+  const previewPackageJsonPath = resolveProjectPackage(
+    TYPESCRIPT_PREVIEW_PACKAGE_JSON,
+    rootPath,
+  );
+  const supportsTsgo = isTypeScriptGoSupportedPackage(packageJsonPath);
+
+  return {
+    typescriptPath,
+    packageJsonPath,
+    previewPackageJsonPath,
+    supportsTsgo,
+    defaultPath: supportsTsgo ? packageJsonPath : typescriptPath,
+  };
+};
+
+const applyTypeScriptPathCompat = (
+  typescriptOptions: TypeScriptOptions | undefined,
+  projectPaths: ProjectTypeScriptPaths,
+): boolean => {
+  if (!typescriptOptions) {
+    return false;
+  }
+
+  const configuredPath = typescriptOptions.typescriptPath;
+
+  if (
+    typescriptOptions.tsgo === false &&
+    configuredPath === projectPaths.packageJsonPath
+  ) {
+    typescriptOptions.typescriptPath = projectPaths.typescriptPath;
+  } else if (
+    typescriptOptions.tsgo !== false &&
+    projectPaths.supportsTsgo &&
+    (configuredPath === projectPaths.typescriptPath ||
+      configuredPath === projectPaths.packageJsonPath ||
+      configuredPath === TYPESCRIPT_PACKAGE ||
+      configuredPath === TYPESCRIPT_PACKAGE_JSON)
+  ) {
+    typescriptOptions.typescriptPath = projectPaths.packageJsonPath;
+  } else if (
+    typescriptOptions.tsgo &&
+    !projectPaths.supportsTsgo &&
+    (!configuredPath ||
+      configuredPath === projectPaths.typescriptPath ||
+      configuredPath === TYPESCRIPT_PACKAGE)
+  ) {
+    typescriptOptions.typescriptPath = projectPaths.previewPackageJsonPath;
+  }
+
+  return (
+    Boolean(typescriptOptions.tsgo) ||
+    (typescriptOptions.tsgo !== false &&
+      isTypeScriptGoSupportedPackage(typescriptOptions.typescriptPath))
+  );
 };
 
 export type PluginTypeCheckerOptions = {
@@ -95,13 +196,7 @@ export const pluginTypeCheck = (
           );
           const useReference =
             Array.isArray(references) && references.length > 0;
-          // use typescript of user project
-          const projectTypescriptPath = resolveProjectPackage(
-            'typescript',
-            api.context.rootPath,
-          );
-          const projectTsgoPath = resolveProjectPackage(
-            '@typescript/native-preview/package.json',
+          const projectTypescriptPaths = resolveProjectTypeScriptPaths(
             api.context.rootPath,
           );
 
@@ -116,9 +211,9 @@ export const pluginTypeCheck = (
               memoryLimit: 8192,
               // use tsconfig of user project
               configFile: tsconfigPath,
-              tsgo: false,
-              // use typescript of user project
-              typescriptPath: projectTypescriptPath,
+              // use TypeScript of user project.
+              // TypeScript 7+ must point to package.json.
+              typescriptPath: projectTypescriptPaths.defaultPath,
             },
             issue: {
               // ignore types errors from node_modules
@@ -145,22 +240,16 @@ export const pluginTypeCheck = (
             mergeFn: deepmerge,
           });
 
-          // Switch the plugin-provided TypeScript path for tsgo after user options are merged.
-          if (
-            mergedOptions.typescript &&
-            mergedOptions.typescript.tsgo &&
-            mergedOptions.typescript.typescriptPath === projectTypescriptPath
-          ) {
-            mergedOptions.typescript.typescriptPath = projectTsgoPath;
-          }
+          const typescriptOptions = mergedOptions.typescript;
+          const isTypeScriptGoEnabled = applyTypeScriptPathCompat(
+            typescriptOptions,
+            projectTypescriptPaths,
+          );
 
-          if (
-            mergedOptions.typescript &&
-            !mergedOptions.typescript.typescriptPath
-          ) {
-            const typeCheckerPackage = mergedOptions.typescript.tsgo
-              ? '@typescript/native-preview'
-              : 'typescript';
+          if (typescriptOptions && !typescriptOptions.typescriptPath) {
+            const typeCheckerPackage = isTypeScriptGoEnabled
+              ? TYPESCRIPT_PREVIEW_PACKAGE
+              : TYPESCRIPT_PACKAGE;
             logger.warn(
               `"${typeCheckerPackage}" is not found in current project, Type checker will not work.`,
             );
@@ -169,7 +258,7 @@ export const pluginTypeCheck = (
 
           if (isProd) {
             logger.info(
-              mergedOptions.typescript?.tsgo
+              isTypeScriptGoEnabled
                 ? 'Type checker is enabled.'
                 : 'Type checker is enabled. It may take some time. You can enable `typescript.tsgo` to speed up type checking.',
             );

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,11 +42,11 @@ const resolveProjectPackage = (
   }
 };
 
-const isTypeScriptGoSupportedPackage = (
+const getTypeScriptGoPackage = (
   packageJsonPath: string | undefined,
-): boolean => {
+): TypeScriptGoPackage | undefined => {
   if (!packageJsonPath) {
-    return false;
+    return undefined;
   }
 
   try {
@@ -55,15 +55,27 @@ const isTypeScriptGoSupportedPackage = (
       typeof packageJson.version === 'string' ? packageJson.version : '';
     const versionMatch = version.match(/^(\d+)\.(\d+)(?:\.|$|-)/);
 
-    return (
+    if (
       packageJson.name === TYPESCRIPT_PACKAGE &&
-      Boolean(versionMatch) &&
+      versionMatch &&
       Number(versionMatch[1]) >= 7
-    );
+    ) {
+      return 'typescript';
+    }
+
+    if (packageJson.name === TYPESCRIPT_PREVIEW_PACKAGE) {
+      return 'preview';
+    }
+
+    return undefined;
   } catch {
-    return false;
+    return undefined;
   }
 };
+
+const isTypeScriptGoSupportedPackage = (
+  packageJsonPath: string | undefined,
+): boolean => getTypeScriptGoPackage(packageJsonPath) === 'typescript';
 
 const resolveProjectTypeScriptPaths = (
   rootPath: string,
@@ -100,11 +112,17 @@ const applyTypeScriptDefaults = (
     typescriptOptions as TypeScriptOptionsWithTsgoPackage;
 
   if (configuredPath) {
-    return (
-      Boolean(typescriptOptions.tsgo) ||
-      (typescriptOptions.tsgo !== false &&
-        isTypeScriptGoSupportedPackage(configuredPath))
-    );
+    const tsgoPackage = getTypeScriptGoPackage(configuredPath);
+
+    if (typescriptOptions.tsgo === undefined && tsgoPackage === 'typescript') {
+      typescriptOptions.tsgo = true;
+    }
+
+    if (typescriptOptions.tsgo === true && tsgoPackage) {
+      normalizedOptions.tsgoPackage = tsgoPackage;
+    }
+
+    return Boolean(typescriptOptions.tsgo);
   }
 
   if (typescriptOptions.tsgo === false) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,11 @@ const require = createRequire(import.meta.url);
 type TsCheckerOptions = NonNullable<
   ConstructorParameters<typeof TsCheckerRspackPlugin>[0]
 >;
+type TypeScriptGoPackage = 'typescript' | 'preview';
 type TypeScriptOptions = NonNullable<TsCheckerOptions['typescript']>;
+type TypeScriptOptionsWithTsgoPackage = TypeScriptOptions & {
+  tsgoPackage?: TypeScriptGoPackage;
+};
 
 type ProjectTypeScriptPaths = {
   typescriptPath?: string;
@@ -94,6 +98,8 @@ const applyTypeScriptPathCompat = (
   }
 
   const configuredPath = typescriptOptions.typescriptPath;
+  const normalizedOptions =
+    typescriptOptions as TypeScriptOptionsWithTsgoPackage;
 
   if (
     typescriptOptions.tsgo === false &&
@@ -109,6 +115,8 @@ const applyTypeScriptPathCompat = (
       configuredPath === TYPESCRIPT_PACKAGE_JSON)
   ) {
     typescriptOptions.typescriptPath = projectPaths.packageJsonPath;
+    typescriptOptions.tsgo ??= true;
+    normalizedOptions.tsgoPackage ??= 'typescript';
   } else if (
     typescriptOptions.tsgo &&
     !projectPaths.supportsTsgo &&
@@ -117,6 +125,7 @@ const applyTypeScriptPathCompat = (
       configuredPath === TYPESCRIPT_PACKAGE)
   ) {
     typescriptOptions.typescriptPath = projectPaths.previewPackageJsonPath;
+    normalizedOptions.tsgoPackage ??= 'preview';
   }
 
   return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,151 +1,13 @@
 import fs from 'node:fs';
-import { createRequire } from 'node:module';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import deepmerge from 'deepmerge';
 import json5 from 'json5';
 import { type ConfigChain, reduceConfigs } from 'reduce-configs';
 import { TsCheckerRspackPlugin } from 'ts-checker-rspack-plugin';
 
-const require = createRequire(import.meta.url);
-
 type TsCheckerOptions = NonNullable<
   ConstructorParameters<typeof TsCheckerRspackPlugin>[0]
 >;
-type TypeScriptGoPackage = 'typescript' | 'preview';
-type TypeScriptOptions = NonNullable<TsCheckerOptions['typescript']>;
-type TypeScriptOptionsWithTsgoPackage = TypeScriptOptions & {
-  tsgoPackage?: TypeScriptGoPackage;
-};
-
-type ProjectTypeScriptPaths = {
-  typescriptPath?: string;
-  packageJsonPath?: string;
-  previewPackageJsonPath?: string;
-  supportsTsgo: boolean;
-};
-
-const TYPESCRIPT_PACKAGE = 'typescript';
-const TYPESCRIPT_PACKAGE_JSON = `${TYPESCRIPT_PACKAGE}/package.json`;
-const TYPESCRIPT_PREVIEW_PACKAGE = '@typescript/native-preview';
-const TYPESCRIPT_PREVIEW_PACKAGE_JSON = `${TYPESCRIPT_PREVIEW_PACKAGE}/package.json`;
-
-const resolveProjectPackage = (
-  packageName: string,
-  rootPath: string,
-): string | undefined => {
-  try {
-    return require.resolve(packageName, {
-      paths: [rootPath],
-    });
-  } catch {
-    return undefined;
-  }
-};
-
-const getTypeScriptGoPackage = (
-  packageJsonPath: string | undefined,
-): TypeScriptGoPackage | undefined => {
-  if (!packageJsonPath) {
-    return undefined;
-  }
-
-  try {
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
-    const version =
-      typeof packageJson.version === 'string' ? packageJson.version : '';
-    const versionMatch = version.match(/^(\d+)\.(\d+)(?:\.|$|-)/);
-
-    if (
-      packageJson.name === TYPESCRIPT_PACKAGE &&
-      versionMatch &&
-      Number(versionMatch[1]) >= 7
-    ) {
-      return 'typescript';
-    }
-
-    if (packageJson.name === TYPESCRIPT_PREVIEW_PACKAGE) {
-      return 'preview';
-    }
-
-    return undefined;
-  } catch {
-    return undefined;
-  }
-};
-
-const isTypeScriptGoSupportedPackage = (
-  packageJsonPath: string | undefined,
-): boolean => getTypeScriptGoPackage(packageJsonPath) === 'typescript';
-
-const resolveProjectTypeScriptPaths = (
-  rootPath: string,
-): ProjectTypeScriptPaths => {
-  const typescriptPath = resolveProjectPackage(TYPESCRIPT_PACKAGE, rootPath);
-  const packageJsonPath = resolveProjectPackage(
-    TYPESCRIPT_PACKAGE_JSON,
-    rootPath,
-  );
-  const previewPackageJsonPath = resolveProjectPackage(
-    TYPESCRIPT_PREVIEW_PACKAGE_JSON,
-    rootPath,
-  );
-  const supportsTsgo = isTypeScriptGoSupportedPackage(packageJsonPath);
-
-  return {
-    typescriptPath,
-    packageJsonPath,
-    previewPackageJsonPath,
-    supportsTsgo,
-  };
-};
-
-const applyTypeScriptDefaults = (
-  typescriptOptions: TypeScriptOptions | undefined,
-  projectPaths: ProjectTypeScriptPaths,
-): boolean => {
-  if (!typescriptOptions) {
-    return false;
-  }
-
-  const configuredPath = typescriptOptions.typescriptPath;
-  const normalizedOptions =
-    typescriptOptions as TypeScriptOptionsWithTsgoPackage;
-
-  if (configuredPath) {
-    const tsgoPackage = getTypeScriptGoPackage(configuredPath);
-
-    if (typescriptOptions.tsgo === undefined && tsgoPackage === 'typescript') {
-      typescriptOptions.tsgo = true;
-    }
-
-    if (typescriptOptions.tsgo === true && tsgoPackage) {
-      normalizedOptions.tsgoPackage = tsgoPackage;
-    }
-
-    return Boolean(typescriptOptions.tsgo);
-  }
-
-  if (typescriptOptions.tsgo === false) {
-    typescriptOptions.typescriptPath = projectPaths.typescriptPath;
-    return false;
-  }
-
-  if (projectPaths.supportsTsgo) {
-    typescriptOptions.typescriptPath = projectPaths.packageJsonPath;
-    typescriptOptions.tsgo = true;
-    normalizedOptions.tsgoPackage = 'typescript';
-    return true;
-  }
-
-  if (typescriptOptions.tsgo === true) {
-    typescriptOptions.typescriptPath = projectPaths.previewPackageJsonPath;
-    normalizedOptions.tsgoPackage = 'preview';
-    return true;
-  }
-
-  typescriptOptions.typescriptPath = projectPaths.typescriptPath;
-  return false;
-};
 
 export type PluginTypeCheckerOptions = {
   /**
@@ -217,9 +79,6 @@ export const pluginTypeCheck = (
           );
           const useReference =
             Array.isArray(references) && references.length > 0;
-          const projectTypescriptPaths = resolveProjectTypeScriptPaths(
-            api.context.rootPath,
-          );
 
           const defaultOptions: TsCheckerOptions = {
             typescript: {
@@ -232,6 +91,8 @@ export const pluginTypeCheck = (
               memoryLimit: 8192,
               // use tsconfig of user project
               configFile: tsconfigPath,
+              // resolve the default TypeScript package from user project
+              resolveRoot: api.context.rootPath,
             },
             issue: {
               // ignore types errors from node_modules
@@ -258,28 +119,8 @@ export const pluginTypeCheck = (
             mergeFn: deepmerge,
           });
 
-          const typescriptOptions = mergedOptions.typescript;
-          const isTypeScriptGoEnabled = applyTypeScriptDefaults(
-            typescriptOptions,
-            projectTypescriptPaths,
-          );
-
-          if (typescriptOptions && !typescriptOptions.typescriptPath) {
-            const typeCheckerPackage = isTypeScriptGoEnabled
-              ? TYPESCRIPT_PREVIEW_PACKAGE
-              : TYPESCRIPT_PACKAGE;
-            logger.warn(
-              `"${typeCheckerPackage}" is not found in current project, Type checker will not work.`,
-            );
-            return;
-          }
-
           if (isProd) {
-            logger.info(
-              isTypeScriptGoEnabled
-                ? 'Type checker is enabled.'
-                : 'Type checker is enabled. It may take some time. You can enable `typescript.tsgo` to speed up type checking.',
-            );
+            logger.info('Type checker is enabled.');
           }
 
           chain

--- a/test/typescript-v7-rc/index.test.ts
+++ b/test/typescript-v7-rc/index.test.ts
@@ -1,0 +1,58 @@
+import { createRequire } from 'node:module';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, test } from '@playwright/test';
+import { createRsbuild } from '@rsbuild/core';
+import {
+  pluginTypeCheck,
+  type PluginTypeCheckerOptions,
+} from '@rsbuild/plugin-type-check';
+import { proxyConsole } from '../helper';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+const expectTypeScriptError = async (
+  tsCheckerOptions?: PluginTypeCheckerOptions['tsCheckerOptions'],
+) => {
+  const typescriptPackageJson = require('typescript/package.json') as {
+    version: string;
+  };
+  expect(typescriptPackageJson.version).toMatch(/^7\./);
+
+  const { logs, restore } = proxyConsole();
+
+  try {
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
+      rsbuildConfig: {
+        plugins: [pluginTypeCheck({ tsCheckerOptions })],
+      },
+    });
+
+    await expect(rsbuild.build()).rejects.toThrowError('build failed');
+
+    expect(logs.some((log) => log.includes('TS2345'))).toBeTruthy();
+    expect(
+      logs.some((log) =>
+        log.includes(
+          `Argument of type 'string' is not assignable to parameter of type 'number'.`,
+        ),
+      ),
+    ).toBeTruthy();
+  } finally {
+    restore();
+  }
+};
+
+test('should type check with TypeScript v7 RC', async () => {
+  await expectTypeScriptError();
+});
+
+test('should type check with TypeScript v7 RC and package specifier path', async () => {
+  await expectTypeScriptError({
+    typescript: {
+      typescriptPath: 'typescript',
+    },
+  });
+});

--- a/test/typescript-v7-rc/index.test.ts
+++ b/test/typescript-v7-rc/index.test.ts
@@ -48,11 +48,3 @@ const expectTypeScriptError = async (
 test('should type check with TypeScript v7 RC', async () => {
   await expectTypeScriptError();
 });
-
-test('should type check with TypeScript v7 RC and package specifier path', async () => {
-  await expectTypeScriptError({
-    typescript: {
-      typescriptPath: 'typescript',
-    },
-  });
-});

--- a/test/typescript-v7-rc/package.json
+++ b/test/typescript-v7-rc/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@e2e/typescript-v7-rc",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@rsbuild/plugin-type-check": "workspace:*",
+    "typescript": "7.0.1-rc"
+  }
+}

--- a/test/typescript-v7-rc/src/index.ts
+++ b/test/typescript-v7-rc/src/index.ts
@@ -1,0 +1,6 @@
+const add = (a: number, b: number) => a + b;
+
+// this is a type error
+const res = add(1, '2');
+
+console.log('res', res);

--- a/test/typescript-v7-rc/tsconfig.json
+++ b/test/typescript-v7-rc/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["DOM", "ESNext"],
+    "module": "ES2020",
+    "strict": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "types": []
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- Upgrade `ts-checker-rspack-plugin` to `^1.5.1`.
- Delegate default TypeScript runtime resolution to `ts-checker-rspack-plugin` via `typescript.resolveRoot` instead of resolving and rewriting `typescriptPath` in this plugin.
- Update the README default options and TypeScript Go guidance for the new behavior.
- Add a TypeScript 7 RC fixture to cover automatic TypeScript Go type checking.