### PR TITLE
docs: update TypeScript 7 install tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,17 +144,17 @@ const defaultOptions = {
 
 TypeScript Go support is powered by `ts-checker-rspack-plugin`'s experimental, CLI-based integration for [typescript-go](https://github.com/microsoft/typescript-go). It runs the TypeScript Go checker binary for type checking and can reduce type-checking time by about 5-10x.
 
-Install TypeScript 7.0 RC to use TypeScript Go automatically:
+Install the latest TypeScript to use TypeScript Go automatically:
 
 ```sh
 # with npm
-npm install -D typescript@rc
+npm install -D typescript@latest
 
 # with yarn
-yarn add -D typescript@rc
+yarn add -D typescript@latest
 
 # with pnpm
-pnpm add -D typescript@rc
+pnpm add -D typescript@latest
 ```
 
 You can also install `@typescript/native-preview` and set `typescript.tsgo` to `true`:
@@ -171,7 +171,7 @@ pluginTypeCheck({
 
 When `tsgo` is enabled and `typescript.typescriptPath` is set manually, it must point to an absolute `typescript/package.json` path from TypeScript 7+ or `@typescript/native-preview/package.json`.
 
-> The `@typescript/native-preview` usage is deprecated and kept only for compatibility. We recommend installing `typescript@rc` to use `tsgo`.
+> The `@typescript/native-preview` usage is deprecated and kept only for compatibility. We recommend installing `typescript@latest` to use `tsgo`.
 
 For supported options and limitations, see [ts-checker-rspack-plugin - TypeScript Go support](https://github.com/rstackjs/ts-checker-rspack-plugin#typescript-go-support).
 

--- a/test/typescript-v7/index.test.ts
+++ b/test/typescript-v7/index.test.ts
@@ -45,6 +45,6 @@ const expectTypeScriptError = async (
   }
 };
 
-test('should type check with TypeScript v7 RC', async () => {
+test('should type check with TypeScript v7 latest', async () => {
   await expectTypeScriptError();
 });


### PR DESCRIPTION
## Summary

This PR updates the TypeScript Go documentation now that TypeScript 7 is available through the normal `typescript@latest` tag instead of the RC tag. It also refreshes the TypeScript v7 test title to avoid RC wording without changing the package version range.

## Related Links

https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/