### PR TITLE
chore: update TypeScript to 7.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "playwright": "^1.61.1",
     "prettier": "^3.9.4",
     "simple-git-hooks": "^2.13.1",
-    "typescript": "^6.0.3"
+    "typescript": "^7.0.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "^1.0.0 || ^2.0.0-0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 1.1.2
       ts-checker-rspack-plugin:
         specifier: ^1.5.1
-        version: 1.5.1(@rspack/core@2.1.2(@swc/helpers@0.5.23))(@typescript/native-preview@7.0.0-dev.20260630.1)(tslib@2.8.1)(typescript@6.0.3)
+        version: 1.5.1(@rspack/core@2.1.2(@swc/helpers@0.5.23))(@typescript/native-preview@7.0.0-dev.20260630.1)(tslib@2.8.1)(typescript@7.0.2)
     devDependencies:
       '@playwright/test':
         specifier: ^1.61.1
@@ -29,7 +29,7 @@ importers:
         version: 2.1.2
       '@rslib/core':
         specifier: ^0.23.1
-        version: 0.23.1(@typescript/native-preview@7.0.0-dev.20260630.1)(typescript@6.0.3)
+        version: 0.23.1(@typescript/native-preview@7.0.0-dev.20260630.1)(typescript@7.0.2)
       '@rslint/core':
         specifier: ^0.6.4
         version: 0.6.4
@@ -55,8 +55,8 @@ importers:
         specifier: ^2.13.1
         version: 2.13.1
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: ^7.0.2
+        version: 7.0.2
 
   test/typescript-v7:
     devDependencies:
@@ -782,11 +782,6 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@6.0.3:
-    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   typescript@7.0.2:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
     engines: {node: '>=16.20.0'}
@@ -1004,12 +999,12 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rslib/core@0.23.1(@typescript/native-preview@7.0.0-dev.20260630.1)(typescript@6.0.3)':
+  '@rslib/core@0.23.1(@typescript/native-preview@7.0.0-dev.20260630.1)(typescript@7.0.2)':
     dependencies:
       '@rsbuild/core': 2.1.2
-      rsbuild-plugin-dts: 0.23.1(@rsbuild/core@2.1.2)(@typescript/native-preview@7.0.0-dev.20260630.1)(typescript@6.0.3)
+      rsbuild-plugin-dts: 0.23.1(@rsbuild/core@2.1.2)(@typescript/native-preview@7.0.0-dev.20260630.1)(typescript@7.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
       - '@typescript/native-preview'
@@ -1343,13 +1338,13 @@ snapshots:
 
   reduce-configs@1.1.2: {}
 
-  rsbuild-plugin-dts@0.23.1(@rsbuild/core@2.1.2)(@typescript/native-preview@7.0.0-dev.20260630.1)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.23.1(@rsbuild/core@2.1.2)(@typescript/native-preview@7.0.0-dev.20260630.1)(typescript@7.0.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 2.1.2
     optionalDependencies:
       '@typescript/native-preview': 7.0.0-dev.20260630.1
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   simple-git-hooks@2.13.1: {}
 
@@ -1365,13 +1360,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  ts-checker-rspack-plugin@1.5.1(@rspack/core@2.1.2(@swc/helpers@0.5.23))(@typescript/native-preview@7.0.0-dev.20260630.1)(tslib@2.8.1)(typescript@6.0.3):
+  ts-checker-rspack-plugin@1.5.1(@rspack/core@2.1.2(@swc/helpers@0.5.23))(@typescript/native-preview@7.0.0-dev.20260630.1)(tslib@2.8.1)(typescript@7.0.2):
     dependencies:
       '@rspack/lite-tapable': 1.1.2
       chokidar: 3.6.0
       memfs: 4.57.8(tslib@2.8.1)
       picocolors: 1.1.1
-      typescript: 6.0.3
+      typescript: 7.0.2
     optionalDependencies:
       '@rspack/core': 2.1.2(@swc/helpers@0.5.23)
       '@typescript/native-preview': 7.0.0-dev.20260630.1
@@ -1379,8 +1374,6 @@ snapshots:
       - tslib
 
   tslib@2.8.1: {}
-
-  typescript@6.0.3: {}
 
   typescript@7.0.2:
     optionalDependencies:


### PR DESCRIPTION
## Summary

This PR updates TypeScript to 7.0.2 and refreshes the pnpm lockfile.
It also adds TypeScript package exclusions to pnpm's minimum release age policy so installs can resolve the new TypeScript platform packages.
Validated with `pnpm install --frozen-lockfile`, `pnpm build` when available, and `pnpm test` when available.

## Related Links

https://github.com/microsoft/TypeScript/releases/tag/v7.0.2